### PR TITLE
Handle same item splitting in separate packages

### DIFF
--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -63,6 +63,81 @@ describe('has one package with all items', () => {
   })
 })
 
+describe(
+  'has an item with quantity 3 and only one unit is in a package',
+  () => {
+    it('should create one package and one delivery', () => {
+      const items = [{ id: 0, quantity: 3, seller: '1' }]
+      const packageAttachment = {
+        packages: [createPackage([{ itemIndex: 0, quantity: 1 }])],
+      }
+      const selectedAddresses = [residentialAddress]
+      const logisticsInfo = [
+        {
+          ...baseLogisticsInfo.express,
+          itemIndex: 0,
+          slas: [expressSla],
+        },
+      ]
+
+      const result = packagify({
+        items,
+        packageAttachment,
+        shippingData: {
+          selectedAddresses,
+          logisticsInfo,
+        },
+      })
+
+      expect(result).toHaveLength(2)
+      expect(result[0].items).toHaveLength(1)
+      expect(result[0].items[0].quantity).toBe(1)
+      expect(result[1].items).toHaveLength(1)
+      expect(result[1].items[0].quantity).toBe(2)
+    })
+  }
+)
+
+describe(
+  'has an item with quantity 3 and one unit is in a package and other unit in another',
+  () => {
+    it('should create two packages and one delivery', () => {
+      const items = [{ id: 0, quantity: 3, seller: '1' }]
+      const packageAttachment = {
+        packages: [
+          createPackage([{ itemIndex: 0, quantity: 1 }]),
+          createPackage([{ itemIndex: 0, quantity: 1 }]),
+        ],
+      }
+      const selectedAddresses = [residentialAddress]
+      const logisticsInfo = [
+        {
+          ...baseLogisticsInfo.express,
+          itemIndex: 0,
+          slas: [expressSla],
+        },
+      ]
+
+      const result = packagify({
+        items,
+        packageAttachment,
+        shippingData: {
+          selectedAddresses,
+          logisticsInfo,
+        },
+      })
+
+      expect(result).toHaveLength(3)
+      expect(result[0].items).toHaveLength(1)
+      expect(result[0].items[0].quantity).toBe(1)
+      expect(result[1].items).toHaveLength(1)
+      expect(result[1].items[0].quantity).toBe(1)
+      expect(result[2].items).toHaveLength(1)
+      expect(result[2].items[0].quantity).toBe(1)
+    })
+  }
+)
+
 describe('has one package and a delivery', () => {
   it('should create two packages', () => {
     const items = createItems(2)


### PR DESCRIPTION
É possível que unidades diferentes do mesmo produto sejam entregues em pacotes diferentes. Esse PR trata esse caso.

Exemplo tirado dos testes:

```js
// O pedido tem 1 item com 3 unidades
const items = [{ id: 0, quantity: 3, seller: '1' }]

// Existe um pacote que entrega apenas 1 unidade deste item
const packageAttachment = {
  packages: [createPackage([{ itemIndex: 0, quantity: 1 }])],
}
```

O que é esperado:

```js
// Que separe em dois pacotes
expect(result).toHaveLength(2)

// O primeiro pacote (que foi entregue) tem 1 item com 1 unidade dele
expect(result[0].items).toHaveLength(1)
expect(result[0].items[0].quantity).toBe(1)

// O segundo pacote (a ser entregue) tem 1 item com 2 unidades
expect(result[1].items).toHaveLength(1)
expect(result[1].items[0].quantity).toBe(2)
```