### PR TITLE
Fix deliveryChannel for OMS' order format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/delivery-packages",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -263,7 +263,7 @@ function getLogisticsInfoData({ itemIndex, logisticsInfo }) {
     selectedSla: logisticsInfo[itemIndex].selectedSla,
     shippingEstimate: selectedSla ? selectedSla.shippingEstimate : undefined,
     shippingEstimateDate: logisticsInfo[itemIndex].shippingEstimateDate ? logisticsInfo[itemIndex].shippingEstimateDate : selectedSla ? selectedSla.shippingEstimateDate : undefined,
-    deliveryChannel: logisticsInfo[itemIndex].selectedDeliveryChannel,
+    deliveryChannel: logisticsInfo[itemIndex].selectedDeliveryChannel ? logisticsInfo[itemIndex].selectedDeliveryChannel : selectedSla ? selectedSla.deliveryChannel : undefined,
     deliveryWindow: logisticsInfo[itemIndex].deliveryWindow,
     deliveryIds: logisticsInfo[itemIndex].deliveryIds,
     slas: logisticsInfo[itemIndex].slas,

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -51,7 +51,6 @@ describe('has one package with all items', () => {
     expect(result).toHaveLength(1)
     expect(result[0].items).toHaveLength(2)
     expect(result[0].selectedSla).toBe(expressSla.id)
-    expect(result[0].deliveryIds).toBeDefined()
     expect(result[0].deliveryChannel).toBe(
       baseLogisticsInfo.express.selectedDeliveryChannel
     )
@@ -648,4 +647,36 @@ describe('has two deliveries', () => {
       }
     )
   })
+})
+
+it('should handle an order in OMS format', () => {
+  const items = createItems(1)
+  const packageAttachment = {
+    packages: [createPackage([{ itemIndex: 0, quantity: 1 }])],
+  }
+  const selectedAddresses = [residentialAddress]
+  const logisticsInfo = [
+    {
+      ...baseLogisticsInfo.normalOms,
+      itemIndex: 0,
+      slas: [normalSla],
+    },
+  ]
+
+  const order = {
+    items,
+    packageAttachment,
+    shippingData: {
+      selectedAddresses,
+      logisticsInfo,
+    },
+  }
+
+  const result = parcelify(order)
+
+  expect(result).toHaveLength(1)
+  expect(result[0].items).toHaveLength(1)
+  expect(result[0].selectedSla).toBe(normalSla.id)
+  expect(result[0].deliveryIds).toBeDefined()
+  expect(result[0].deliveryChannel).toBe(normalSla.deliveryChannel)
 })

--- a/tests/mockGenerator.js
+++ b/tests/mockGenerator.js
@@ -104,7 +104,6 @@ const baseLogisticsInfo = {
     addressId: residentialAddress.addressId,
     selectedSla: expressSla.id,
     selectedDeliveryChannel: 'delivery',
-    deliveryIds: [{ courierId: '123' }],
   },
   normal: {
     addressId: residentialAddress.addressId,
@@ -115,6 +114,11 @@ const baseLogisticsInfo = {
     addressId: residentialAddress.addressId,
     selectedSla: normalFastestSla.id,
     selectedDeliveryChannel: 'delivery',
+  },
+  normalOms: {
+    addressId: residentialAddress.addressId,
+    selectedSla: normalSla.id,
+    deliveryIds: [{ courierId: '123' }],
   },
 }
 


### PR DESCRIPTION
Uma order no OMS não tem o campo `selectedDeliveryChannel`, por conta disso o `deliveryChannel` vinha `null`.

Esse PR trata esse caso, pegando fallback de dentro do SLA.