### PR TITLE
Fix orders with devolution packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/delivery-packages",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -181,10 +181,9 @@ function getDeliveredItems({ items, packages }) {
       }, 0)
 
       const packageDeliveredAllItems = quantityInPackages === item.quantity
+      const quantityLeftToDeliver = item.quantity - quantityInPackages
 
-      if (packageDeliveredAllItems === false) {
-        const quantityLeftToDeliver = item.quantity - quantityInPackages
-
+      if (packageDeliveredAllItems === false && quantityLeftToDeliver > 0) {
         groups.toBeDelivered = groups.toBeDelivered.concat({
           item: Object.assign({}, item, { quantity: quantityLeftToDeliver }),
         })

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -680,3 +680,40 @@ it('should handle an order in OMS format', () => {
   expect(result[0].deliveryIds).toBeDefined()
   expect(result[0].deliveryChannel).toBe(normalSla.deliveryChannel)
 })
+
+it('should handle devolution packages', () => {
+  const items = createItems(1)
+  const packageAttachment = {
+    packages: [
+      {
+        ...createPackage([{ itemIndex: 0, quantity: 1 }]),
+        type: 'Output',
+      },
+      {
+        ...createPackage([{ itemIndex: 0, quantity: 1 }]),
+        type: 'Input',
+      },
+    ],
+  }
+  const selectedAddresses = [residentialAddress]
+  const logisticsInfo = [
+    {
+      ...baseLogisticsInfo.normalOms,
+      itemIndex: 0,
+      slas: [normalSla],
+    },
+  ]
+
+  const order = {
+    items,
+    packageAttachment,
+    shippingData: {
+      selectedAddresses,
+      logisticsInfo,
+    },
+  }
+
+  const result = parcelify(order)
+
+  expect(result).toHaveLength(2)
+})


### PR DESCRIPTION
É possivel que um item seja devolvido para a loja. Nesse caso é criado uma nota de entrada (é um package com `type: 'Input'`).

O calculo feito fazia com que fosse criado 3 parcels:

1. Package de entrega
2. Package de entrada (devolução)
3. Um terceiro parcel com quantidade do item como `-1`

Isso acontecia por conta do seguinte trecho:
```js
// item.quantity = 1
// quantityInPackages = 2 (1 do package de entrega e 1 do package de entrada)

const quantityLeftToDeliver = item.quantity - quantityInPackages
// quantityLeftToDeliver = -1
```

Criei uma nova condição de apenas criar um novo parcel apenas se ainda sobrarem items a serem enviados, ou seja,  `quantityLeftToDeliver > 0`.