### PR TITLE
Handle order changes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,20 @@
 {
-  "presets": [
-    [
-      "env",
-      {
-        "modules": false
-      }
-    ]
-  ]
+  "plugins": [
+    "babel-plugin-transform-object-rest-spread"
+  ],
+  "env": {
+    "test": {
+      "presets": ["env"]
+    },
+    "production": {
+      "presets": [
+        [
+          "env",
+          {
+            "modules": false
+          }
+        ]
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/delivery-packages",
-  "version": "2.1.8",
+  "version": "2.2.0",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "dist"
   ],
   "scripts": {
-    "test": "jest",
-    "prepublishOnly": "rollup -c"
+    "test": "cross-env NODE_ENV=test jest",
+    "build": "cross-env NODE_ENV=production rollup -c",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "vtex",
@@ -29,7 +30,9 @@
     "babel-core": "6",
     "babel-eslint": "^8.2.2",
     "babel-jest": "^22.2.2",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
+    "cross-env": "^5.1.4",
     "eslint": "^4.18.0",
     "eslint-config-vtex": "^8.0.0",
     "eslint-plugin-jest": "^21.12.2",
@@ -49,6 +52,6 @@
     ]
   },
   "dependencies": {
-    "@vtex/estimate-calculator": "^1.0.0"
+    "@vtex/estimate-calculator": "^1.0.8"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,17 +13,14 @@ export default [
       file: pkg.browser,
       format: 'umd',
       sourcemap: true,
-      globals: {
-        '@vtex/estimate-calculator': 'vtex.EstimateCalculator',
-      },
     },
     plugins: [
-      resolve(), // so Rollup can find `ms`
+      resolve(),
       babel({
-        exclude: 'node_modules/**', // only transpile our source code
+        exclude: 'node_modules/**',
       }),
       uglify(),
-      commonjs(), // so Rollup can convert `ms` to an ES module
+      commonjs(),
     ],
   },
 
@@ -35,7 +32,13 @@ export default [
   // `file` and `format` for each target)
   {
     input: 'src/index.js',
-    external: ['ms'],
+    plugins: [
+      resolve(),
+      babel({
+        exclude: 'node_modules/**',
+      }),
+      commonjs(),
+    ],
     output: [
       { file: pkg.main, format: 'cjs', sourcemap: true },
       { file: pkg.module, format: 'es', sourcemap: true },

--- a/src/index.js
+++ b/src/index.js
@@ -12,11 +12,10 @@ const defaultCriteria = {
 
 module.exports = function(order, options = {}) {
   const { items = [], packageAttachment = {}, shippingData = {} } = order
-  const criteria = Object.assign(
-    {},
-    defaultCriteria,
-    options.criteria ? options.criteria : {}
-  )
+  const criteria = {
+    ...defaultCriteria,
+    ...(options.criteria ? options.criteria : {}),
+  }
 
   const packages = packageAttachment && packageAttachment.packages
     ? packageAttachment.packages
@@ -28,10 +27,8 @@ module.exports = function(order, options = {}) {
     ? shippingData.selectedAddresses
     : []
 
-  const itemsWithIndex = items.map((item, index) =>
-    Object.assign({}, item, { index }))
-  const packagesWithIndex = packages.map((pack, index) =>
-    Object.assign({}, pack, { index }))
+  const itemsWithIndex = items.map((item, index) => ({ ...item, index }))
+  const packagesWithIndex = packages.map((pack, index) => ({ ...pack, index }))
 
   const deliveredItems = getDeliveredItems({
     items: itemsWithIndex,
@@ -126,31 +123,28 @@ function addToPackage(items, criteria, fn) {
         return packages
       }
 
-      const newPackage = Object.assign(
-        {},
-        {
-          items: [item.item],
-          package: item.package,
-          slas: item.slas,
-          pickupFriendlyName: criteria.selectedSla
-            ? item.pickupFriendlyName
-            : undefined,
-          seller: criteria.seller ? item.item.seller : undefined,
-          address: criteria.selectedSla ? item.address : undefined,
-          selectedSla: criteria.selectedSla ? item.selectedSla : undefined,
-          deliveryIds: item.deliveryIds,
-          deliveryChannel: criteria.deliveryChannel
-            ? item.deliveryChannel
-            : undefined,
-          shippingEstimate: criteria.selectedSla
-            ? item.shippingEstimate
-            : undefined,
-          shippingEstimateDate: criteria.selectedSla
-            ? item.shippingEstimateDate
-            : undefined,
-          item: undefined,
-        }
-      )
+      const newPackage = {
+        items: [item.item],
+        package: item.package,
+        slas: item.slas,
+        pickupFriendlyName: criteria.selectedSla
+          ? item.pickupFriendlyName
+          : undefined,
+        seller: criteria.seller ? item.item.seller : undefined,
+        address: criteria.selectedSla ? item.address : undefined,
+        selectedSla: criteria.selectedSla ? item.selectedSla : undefined,
+        deliveryIds: item.deliveryIds,
+        deliveryChannel: criteria.deliveryChannel
+          ? item.deliveryChannel
+          : undefined,
+        shippingEstimate: criteria.selectedSla
+          ? item.shippingEstimate
+          : undefined,
+        shippingEstimateDate: criteria.selectedSla
+          ? item.shippingEstimateDate
+          : undefined,
+        item: undefined,
+      }
 
       return packages.concat(newPackage)
     },
@@ -185,7 +179,7 @@ function getDeliveredItems({ items, packages }) {
 
       if (packageDeliveredAllItems === false && quantityLeftToDeliver > 0) {
         groups.toBeDelivered = groups.toBeDelivered.concat({
-          item: Object.assign({}, item, { quantity: quantityLeftToDeliver }),
+          item: { ...item, quantity: quantityLeftToDeliver },
         })
       }
 
@@ -196,7 +190,7 @@ function getDeliveredItems({ items, packages }) {
 
         return {
           package: pack,
-          item: Object.assign({}, item, { quantity: packageItem.quantity }),
+          item: { ...item, quantity: packageItem.quantity },
         }
       })
 
@@ -214,25 +208,22 @@ function createEnhancePackageFn({ logisticsInfo, selectedAddresses }) {
   return pack => {
     const itemIndex = pack.item.index
 
-    return Object.assign(
-      {},
-      pack,
-      {
-        address: getAddress({
-          itemIndex,
-          logisticsInfo,
-          selectedAddresses,
-        }),
-        pickupFriendlyName: getPickupFriendlyName({
-          itemIndex,
-          logisticsInfo,
-        }),
-      },
-      getLogisticsInfoData({
+    return {
+      ...pack,
+      address: getAddress({
         itemIndex,
         logisticsInfo,
-      })
-    )
+        selectedAddresses,
+      }),
+      pickupFriendlyName: getPickupFriendlyName({
+        itemIndex,
+        logisticsInfo,
+      }),
+      ...getLogisticsInfoData({
+        itemIndex,
+        logisticsInfo,
+      }),
+    }
   }
 }
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -717,3 +717,115 @@ it('should handle devolution packages', () => {
 
   expect(result).toHaveLength(2)
 })
+
+describe('the order has changes', () => {
+  it('should remove the item completely when the change has all the quantity', () => {
+    const items = createItems(1)
+    const packageAttachment = { packages: [] }
+    const changesAttachment = {
+      changesData: [
+        {
+          itemsRemoved: [
+            { id: '0', quantity: 1 },
+          ],
+        },
+      ],
+    }
+    const selectedAddresses = [residentialAddress]
+    const logisticsInfo = [
+      {
+        ...baseLogisticsInfo.normalOms,
+        itemIndex: 0,
+        slas: [normalSla],
+      },
+    ]
+
+    const order = {
+      items,
+      packageAttachment,
+      changesAttachment,
+      shippingData: {
+        selectedAddresses,
+        logisticsInfo,
+      },
+    }
+
+    const result = parcelify(order)
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('should remove the right quantity from the item', () => {
+    const items = [{ id: '0', quantity: 2, seller: '1' }]
+    const packageAttachment = { packages: [] }
+    const changesAttachment = {
+      changesData: [
+        {
+          itemsRemoved: [
+            { id: '0', quantity: 1 },
+          ],
+        },
+      ],
+    }
+    const selectedAddresses = [residentialAddress]
+    const logisticsInfo = [
+      {
+        ...baseLogisticsInfo.normalOms,
+        itemIndex: 0,
+        slas: [normalSla],
+      },
+    ]
+
+    const order = {
+      items,
+      packageAttachment,
+      changesAttachment,
+      shippingData: {
+        selectedAddresses,
+        logisticsInfo,
+      },
+    }
+
+    const result = parcelify(order)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].items[0].quantity).toBe(1)
+  })
+
+  it('should add the right quantity to the item', () => {
+    const items = createItems(1)
+    const packageAttachment = { packages: [] }
+    const changesAttachment = {
+      changesData: [
+        {
+          itemsAdded: [
+            { id: '0', quantity: 1 },
+          ],
+        },
+      ],
+    }
+    const selectedAddresses = [residentialAddress]
+    const logisticsInfo = [
+      {
+        ...baseLogisticsInfo.normalOms,
+        itemIndex: 0,
+        slas: [normalSla],
+      },
+    ]
+
+    const order = {
+      items,
+      packageAttachment,
+      changesAttachment,
+      shippingData: {
+        selectedAddresses,
+        logisticsInfo,
+      },
+    }
+
+    const result = parcelify(order)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].items[0].quantity).toBe(2)
+  })
+})

--- a/tests/mockGenerator.js
+++ b/tests/mockGenerator.js
@@ -83,7 +83,7 @@ const normalFastestSla = {
 
 const createItems = quantity => {
   return Array.from(Array(quantity), (_, index) => ({
-    id: index,
+    id: `${index}`,
     quantity: 1,
     seller: '1',
   }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,9 +71,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@vtex/estimate-calculator@^1.0.0":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@vtex/estimate-calculator/-/estimate-calculator-1.0.7.tgz#4b0da3acf8eb05ca47ca8dd25d4eb4d8370b987f"
+"@vtex/estimate-calculator@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@vtex/estimate-calculator/-/estimate-calculator-1.0.8.tgz#33601359cbc061228bf7b4a8c3161ad1974ad93e"
   dependencies:
     lodash "^4.17.5"
 
@@ -463,7 +463,7 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
-babel-plugin-syntax-object-rest-spread@^6.13.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -654,6 +654,13 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
@@ -998,6 +1005,13 @@ core-js@^2.4.0, core-js@^2.5.0:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cross-env@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.4.tgz#f61c14291f7cc653bb86457002ea80a04699d022"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
 
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -1898,6 +1912,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
É possível que um pedido tenha passado por mudanças, como retirada de um item do pedido.

Isso é expresso da seguinte maneira no pedido:

```js
"changesAttachment": {
  "changesData": [
    {
      "reason": "Troca de item",
      "discountValue": 1199,
      "incrementValue": 0,
      "itemsAdded": [ // ****** Aqui temos os itens adicionados:
        {
          "id": "19",
          "name": "Pedigree Adulto Nutricion Completa 10 Kg",
          "quantity": 1,
          "price": 2800
        }
      ],
      "itemsRemoved": [ // ****** Aqui temos os itens removidos:
        {
          "id": "31",
          "name": "Camisa Seleção Brasileira",
          "quantity": 1,
          "price": 3999
        }
      ],
      "receipt": {
        "date": "2018-04-26T13:54:29.8959681+00:00",
        "orderId": "814592958871-01",
        "receipt": "531c5812-521b-4ba7-b328-7c7564ed583b"
      }
    }
  ]
},
```

So levamos em consideração os campos: `itemsAdded` e `itemsRemoved`.

O que esse PR faz é:
- Altera a quantidade dos items baseado nas changes do pedido.
    