### PR TITLE
Handle items without the index property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/delivery-packages",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/items.js
+++ b/src/items.js
@@ -67,7 +67,7 @@ export function getDeliveredItems(params) {
 
       const quantityInPackages = packagesWithItem.reduce((total, pack) => {
         const packageItem = pack.items.find(
-          packageItem => packageItem.itemIndex === item.index
+          packageItem => packageItem.itemIndex === index
         )
 
         return total + packageItem.quantity
@@ -81,10 +81,9 @@ export function getDeliveredItems(params) {
           item: { ...item, quantity: quantityLeftToDeliver },
         })
       }
-
       const delivered = packagesWithItem.map(pack => {
         const packageItem = pack.items.find(
-          packageItem => packageItem.itemIndex === item.index
+          packageItem => packageItem.itemIndex === index
         )
 
         return {

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -215,4 +215,19 @@ describe('Items', () => {
       expect(deliveredItems).toEqual(expectedObj)
     })
   })
+
+  it('should get the right items without the index property', () => {
+    const items = createItems(3)
+    const packages = [
+      createPackage([
+        { itemIndex: 0, quantity: 1 },
+        { itemIndex: 2, quantity: 1 },
+      ]),
+    ]
+
+    const deliveredItems = getDeliveredItems({ items, packages })
+
+    expect(deliveredItems.toBeDelivered).toHaveLength(1)
+    expect(deliveredItems.delivered).toHaveLength(2)
+  })
 })


### PR DESCRIPTION
Isso estava fazendo crashar o OMS, pois eu passava os items sem a propriedade index.