### PR TITLE
Fix pickup point receiverName being null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/delivery-packages",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/shipping.js
+++ b/src/shipping.js
@@ -49,21 +49,7 @@ function getPickupFriendlyName({ itemIndex, logisticsInfo }) {
   return sla && sla.pickupStoreInfo ? sla.pickupStoreInfo.friendlyName : null
 }
 
-function getPickupAddress({ itemIndex, logisticsInfo }) {
-  const sla = getSelectedSla({ itemIndex, logisticsInfo })
-  return sla.pickupStoreInfo ? sla.pickupStoreInfo.address : null
-}
-
 function getAddress({ itemIndex, logisticsInfo, selectedAddresses }) {
-  const selectedSla = getSelectedSla({
-    itemIndex,
-    logisticsInfo,
-  })
-
-  if (selectedSla && selectedSla.deliveryChannel === 'pickup-in-point') {
-    return getPickupAddress({ itemIndex, logisticsInfo })
-  }
-
   const addressId = logisticsInfo[itemIndex].addressId
   return selectedAddresses.find(address => address.addressId === addressId)
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -325,32 +325,6 @@ describe('has one package one with deliveryWindow', () => {
   })
 })
 
-describe('has one pickup point', () => {
-  it('should return the receiverName', () => {
-    const items = createItems(1)
-    const selectedAddresses = [pickupPointAddress]
-    const logisticsInfo = [
-      {
-        ...baseLogisticsInfo.pickup,
-        itemIndex: 0,
-        slas: [pickupSla],
-      },
-    ]
-
-    const order = {
-      items,
-      shippingData: {
-        selectedAddresses,
-        logisticsInfo,
-      },
-    }
-
-    const result = parcelify(order)
-
-    expect(result[0].address.receiverName).toBe(pickupPointAddress.receiverName)
-  })
-})
-
 describe('has two deliveries', () => {
   it('with no selected sla should not crash', () => {
     const items = createItems(2)

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -19,7 +19,7 @@ const {
   pickupSla,
 } = slas
 
-const { residentialAddress } = addresses
+const { residentialAddress, pickupPointAddress } = addresses
 
 describe('has one package with all items', () => {
   it('should create one parcel', () => {
@@ -325,6 +325,32 @@ describe('has one package one with deliveryWindow', () => {
   })
 })
 
+describe('has one pickup point', () => {
+  it('should return the receiverName', () => {
+    const items = createItems(1)
+    const selectedAddresses = [pickupPointAddress]
+    const logisticsInfo = [
+      {
+        ...baseLogisticsInfo.pickup,
+        itemIndex: 0,
+        slas: [pickupSla],
+      },
+    ]
+
+    const order = {
+      items,
+      shippingData: {
+        selectedAddresses,
+        logisticsInfo,
+      },
+    }
+
+    const result = parcelify(order)
+
+    expect(result[0].address.receiverName).toBe(pickupPointAddress.receiverName)
+  })
+})
+
 describe('has two deliveries', () => {
   it('with no selected sla should not crash', () => {
     const items = createItems(2)
@@ -565,7 +591,7 @@ describe('has two deliveries', () => {
           },
         ]
 
-        const selectedAddresses = [residentialAddress]
+        const selectedAddresses = [residentialAddress, pickupPointAddress]
         const logisticsInfo = [
           {
             ...baseLogisticsInfo.normal,

--- a/tests/mockGenerator.js
+++ b/tests/mockGenerator.js
@@ -104,7 +104,10 @@ const slas = {
     pickupStoreInfo: {
       isPickupStore: true,
       friendlyName: 'Shopping da Gávea',
-      address: addresses.pickupPointAddress,
+      address: {
+        ...addresses.pickupPointAddress,
+        receiverName: null,
+      },
     },
   },
   pickupNormalSla: {
@@ -120,7 +123,10 @@ const slas = {
     pickupStoreInfo: {
       isPickupStore: true,
       friendlyName: 'Shopping da Gávea',
-      address: addresses.pickupPointAddress,
+      address: {
+        ...addresses.pickupPointAddress,
+        receiverName: null,
+      },
     },
   },
   expressSla: {

--- a/tests/shipping.test.js
+++ b/tests/shipping.test.js
@@ -9,6 +9,7 @@ import {
 import { getDeliveredItems } from '../src/items'
 
 import {
+  baseLogisticsInfo,
   createLogisticsInfo,
   createItems,
   createPackage,
@@ -251,6 +252,36 @@ describe('Shipping', () => {
       )
 
       expect(newPkg).toEqual(expectedNewPkg)
+    })
+
+    it('should return the pickup point address receiverName', () => {
+      const items = createItems(1)
+      const packages = [
+        createPackage([{ itemIndex: 0, quantity: 1 }]),
+      ]
+      const itemsWithIndex = items.map((item, index) => ({ ...item, index }))
+      const packagesWithIndex = packages.map((pack, index) => ({ ...pack, index }))
+      const logisticsInfo = [
+        {
+          ...baseLogisticsInfo.pickup,
+          itemIndex: 0,
+          slas: [slas.pickupSla],
+        },
+      ]
+      const selectedAddresses = [addresses.pickupPointAddress]
+      const deliveredItems = getDeliveredItems({
+        items: itemsWithIndex,
+        packages: packagesWithIndex,
+      })
+      const pkg = deliveredItems.delivered[0]
+
+      const result = hydratePackageWithLogisticsExtraInfo(
+        pkg,
+        logisticsInfo,
+        selectedAddresses
+      )
+
+      expect(result.address.receiverName).toBe(addresses.pickupPointAddress.receiverName)
     })
   })
 


### PR DESCRIPTION
Antes pegavamos o endereço de um pickup point de dentro do sla em `pickupStoreInfo`.

Porém o endereço contido lá, não possui o campo `receiverName` preenchido.

Este PR altera esse comportamento para pegar o endereço do pickup point de dentro de `selectedAddresses`, address no qual tem o campo `receiverName` preenchido.