### PR TITLE
Feature/send payload with matching addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,12 +284,6 @@ findAddressByPostalCode
 addOrReplaceAddressOnList
 addPickupPointAddresses
 
-sla:
-getPickupSelectedSlas
-
-shipping:
-getNewLogisticsMatchingSelectedAddresses
-
 ## Address
 > @vtex/delivery-packages/dist/address
 
@@ -2267,6 +2261,47 @@ The logisticsInfo like the one inside `orderForm.shippingData` with `selectedSla
 - **selectedSlas**
 Type: `Array<object>`
 the selected slas objects on the logisticsInfo items hydrated with itemIndex reference or empty array in case of wrong or empty params passed
+
+## getPickupSelectedSlas (logisticsInfo)
+
+Get the selected slas objects on logisticsInfo filtered by pickup points type.
+
+##### Usage
+```js
+const { getPickupSelectedSlas } = require('@vtex/delivery-packages/dist/sla')
+
+let logisticsInfo = [
+  {
+    // other logisticsInfo properties can be passed also
+    selectedSla: 'Normal',
+    itemIndex: 0,
+    slas: [
+      { "id": "Normal", "deliveryChannel": "delivery" }, { "id": "Expressa", "deliveryChannel": "delivery" }
+    ]
+  },
+  {
+    // other logisticsInfo properties can be passed also
+    selectedSla: 'Pickup',
+    itemIndex: 1,
+    slas: [
+      { "id": "Normal", "deliveryChannel": "delivery" }, { "id": "Pickup", "deliveryChannel": "pickup-in-point" }
+    ]
+  }
+]
+
+getPickupSelectedSlas(logisticsInfo)
+// -> [{ "itemIndex": 1,  "id": "Pickup", "deliveryChannel": "pickup-in-point" }]
+```
+
+**params:**
+- **logisticsInfo**
+Type: `Array<object>`
+The logisticsInfo like the one inside `orderForm.shippingData` with `selectedSla` and `slas`
+
+**returns:**
+- **selectedPickupSlas**
+Type: `Array<object>`
+the selected slas objects on the logisticsInfo items hydrated with itemIndex reference and filtered by pickup type or empty array in case of wrong or empty params passed
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -276,16 +276,412 @@ parcelify(order, { criteria: { seller: false } })
 
 This module provide a lot of helper functions besides parcelify, that are worth checking below.
 
-address:
-addAddressId
-findAddressIndex
-findAddress
-findAddressByPostalCode
-addOrReplaceAddressOnList
-addPickupPointAddresses
-
 ## Address
 > @vtex/delivery-packages/dist/address
+
+### addAddressId (address)
+
+Add property addressId with random hash string (uuid) if not present on address object passed
+
+#### Usage
+```js
+const { addAddressId } = require('@vtex/delivery-packages/dist/address')
+
+addAddressId({
+  addressType: 'residential',
+  receiverName: 'John Doe',
+  street: 'Rua Barão',
+  number: '2',
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22231-100',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+})
+// -> {
+//   addressId: '935befd9-dcc3-45f3-e327-9d8611e43630',
+//   addressType: 'residential',
+//   receiverName: 'John Doe',
+//   street: 'Rua Barão',
+//   number: '2',
+//   complement: null,
+//   neighborhood: 'Botafogo',
+//   postalCode: '22231-100',
+//   city: 'Rio de Janeiro',
+//   state: 'RJ',
+//   country: 'BRA',
+//   reference: null,
+//   geoCoordinates: [],
+// }
+
+addAddressId({
+  addressId: '1234',
+  addressType: 'residential',
+  receiverName: 'John Doe',
+  street: 'Rua Barão',
+  number: '2',
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22231-100',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+})
+// -> {
+//   addressId: '1234',
+//   addressType: 'residential',
+//   receiverName: 'John Doe',
+//   street: 'Rua Barão',
+//   number: '2',
+//   complement: null,
+//   neighborhood: 'Botafogo',
+//   postalCode: '22231-100',
+//   city: 'Rio de Janeiro',
+//   state: 'RJ',
+//   country: 'BRA',
+//   reference: null,
+//   geoCoordinates: [],
+// }
+```
+
+**params:**
+- **address**
+Type: `object`
+An object containing all address fields like on availableAddresses of orderForm
+
+**returns:**
+- **newAddress**
+Type: `object`
+An object containing all address fields like on availableAddresses of orderForm with an addressId included
+
+### addPickupPointAddresses (addresses, pickupSlas)
+
+Add all addresses present on pickupSlas that are not already on addresses list
+
+#### Usage
+```js
+const { addPickupPointAddresses } = require('@vtex/delivery-packages/dist/address')
+
+addPickupPointAddresses([{
+  addressId: '1234',
+  addressType: 'residential',
+  receiverName: 'John Doe',
+  street: 'Rua Barão',
+  number: '2',
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22231-100',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+}], [{
+  id: 'Retirada normal',
+  deliveryChannel: 'pickup-in-point',
+  pickupStoreInfo: {
+    isPickupStore: true,
+    friendlyName: 'Shopping da Gávea',
+    address: {
+      addressId: '141125e',
+      addressType: 'pickup',
+      city: 'Rio de Janeiro',
+      complement: '',
+      country: 'BRA',
+      geoCoordinates: [-43.18080139160156, -22.96540069580078],
+      neighborhood: 'Copacabana',
+      number: '5',
+      postalCode: '22011050',
+      receiverName: null,
+      reference: null,
+      state: 'RJ',
+      street: 'Rua General Azevedo Pimentel',
+    },
+  },
+}])
+// -> [{
+//   addressId: '1234',
+//   addressType: 'residential',
+//   receiverName: 'John Doe',
+//   street: 'Rua Barão',
+//   number: '2',
+//   complement: null,
+//   neighborhood: 'Botafogo',
+//   postalCode: '22231-100',
+//   city: 'Rio de Janeiro',
+//   state: 'RJ',
+//   country: 'BRA',
+//   reference: null,
+//   geoCoordinates: [],
+// }, {
+//   addressId: '141125e',
+//   addressType: 'pickup',
+//   city: 'Rio de Janeiro',
+//   complement: '',
+//   country: 'BRA',
+//   geoCoordinates: [-43.18080139160156, -22.96540069580078],
+//   neighborhood: 'Copacabana',
+//   number: '5',
+//   postalCode: '22011050',
+//   receiverName: null,
+//   reference: null,
+//   state: 'RJ',
+//   street: 'Rua General Azevedo Pimentel',
+// }]
+```
+**params:**
+- **addresses**
+Type: `Array<object>`
+An array which each item is an object containing all address fields like on availableAddresses of orderForm
+- **pickupSlas**
+Type: `Array<object>`
+An array which each item is an object containing a list of slas of the pickup-in-point deliveryChannel
+
+**returns:**
+- **newAddresses**
+Type: `Array<object>`
+New list of addresses containing the pickup addresses
+
+### findAddressIndex (addresses, searchAddress)
+
+Find a reference address index on addresses list according to the reference addressId or -1 if it doesn't find it
+
+#### Usage
+```js
+const { findAddressIndex } = require('@vtex/delivery-packages/dist/address')
+
+findAddressIndex([{
+  addressId: '935befd9-dcc3-45f3-e327-9d8611e43630',
+  addressType: 'residential',
+  receiverName: 'John Doe',
+  street: 'Rua Barão',
+  number: '2',
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22231-100',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+}, {
+  addressId: '783978bd-e71c-4602-4bc6-387cc68f226d',
+  addressType: 'commercial',
+  receiverName: 'John Doe',
+  street: 'Rua dos bobos',
+  number: '0',
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22250-040',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+}], { addressId: '935befd9-dcc3-45f3-e327-9d8611e43630' })
+// -> 0
+
+findAddressIndex([{
+  addressId: '935befd9-dcc3-45f3-e327-9d8611e43630',
+  addressType: 'residential',
+  receiverName: 'John Doe',
+  street: 'Rua Barão',
+  number: '2',
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22231-100',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+}, {
+  addressId: '783978bd-e71c-4602-4bc6-387cc68f226d',
+  addressType: 'commercial',
+  receiverName: 'John Doe',
+  street: 'Rua dos bobos',
+  number: '0',
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22250-040',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+}], { addressId: 'not-found' })
+// -> -1
+```
+
+**params:**
+- **addresses**
+Type: `Array<object>`
+An array which each item is an object containing all address fields like on availableAddresses of orderForm
+- **searchAddress**
+Type: `object`
+An object with addressId reference to be used to search
+
+**returns:**
+- **index**
+Type: `number`
+Position on addresses of the searchAddress reference according to its addressId
+
+### findAddress (addresses, searchAddress)
+
+Find a reference address on addresses list according to the reference addressId or null if it doesn't find it
+
+#### Usage
+```js
+const { findAddress } = require('@vtex/delivery-packages/dist/address')
+
+findAddress([{
+  addressId: '935befd9-dcc3-45f3-e327-9d8611e43630',
+  addressType: 'residential',
+  receiverName: 'John Doe',
+  street: 'Rua Barão',
+  number: '2',
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22231-100',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+}, {
+  addressId: '783978bd-e71c-4602-4bc6-387cc68f226d',
+  addressType: 'commercial',
+  receiverName: 'John Doe',
+  street: 'Rua dos bobos',
+  number: '0',
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22250-040',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+}], { addressId: '935befd9-dcc3-45f3-e327-9d8611e43630' })
+// -> {
+//   addressId: '935befd9-dcc3-45f3-e327-9d8611e43630',
+//   addressType: 'residential',
+//   receiverName: 'John Doe',
+//   street: 'Rua Barão',
+//   number: '2',
+//   complement: null,
+//   neighborhood: 'Botafogo',
+//   postalCode: '22231-100',
+//   city: 'Rio de Janeiro',
+//   state: 'RJ',
+//   country: 'BRA',
+//   reference: null,
+//   geoCoordinates: []
+// }
+
+findAddress([{
+  addressId: '935befd9-dcc3-45f3-e327-9d8611e43630',
+  addressType: 'residential',
+  receiverName: 'John Doe',
+  street: 'Rua Barão',
+  number: '2',
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22231-100',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+}, {
+  addressId: '783978bd-e71c-4602-4bc6-387cc68f226d',
+  addressType: 'commercial',
+  receiverName: 'John Doe',
+  street: 'Rua dos bobos',
+  number: '0',
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22250-040',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+}], { addressId: 'not-found' })
+// -> null
+```
+
+**params:**
+- **addresses**
+Type: `Array<object>`
+An array which each item is an object containing all address fields like on availableAddresses of orderForm
+- **searchAddress**
+Type: `object`
+An object with addressId reference to be used to search
+
+**returns:**
+- **addressFound**
+Type: `object`
+The address found
+
+### findAddressByPostalCode (addresses, searchAddress)
+
+Works like findAddress above but the searchAddress postalCode property is used instead
+
+#### Usage
+```js
+const { findAddress } = require('@vtex/delivery-packages/dist/address')
+
+findAddress([{
+  addressId: '935befd9-dcc3-45f3-e327-9d8611e43630',
+  addressType: 'residential',
+  receiverName: 'John Doe',
+  street: 'Rua Barão',
+  number: '2',
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22231-100',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+}, {
+  addressId: '783978bd-e71c-4602-4bc6-387cc68f226d',
+  addressType: 'commercial',
+  receiverName: 'John Doe',
+  street: 'Rua dos bobos',
+  number: '0',
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22250-040',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+}], { postalCode: '22250-040' })
+// -> {
+//   addressId: '783978bd-e71c-4602-4bc6-387cc68f226d',
+//   addressType: 'commercial',
+//   receiverName: 'John Doe',
+//   street: 'Rua dos bobos',
+//   number: '0',
+//   complement: null,
+//   neighborhood: 'Botafogo',
+//   postalCode: '22250-040',
+//   city: 'Rio de Janeiro',
+//   state: 'RJ',
+//   country: 'BRA',
+//   reference: null,
+//   geoCoordinates: [],
+// }
+```
 
 ### isAddressComplete (address)
 
@@ -758,6 +1154,171 @@ New address to be included on the list of addresses
 Type: `object`
 New list of addresses with the newAddress included
 
+## addOrReplaceAddressOnList (addresses, newAddress)
+
+Adds new address if the newAddress is not found or replace an existing address with the same addressId
+
+##### Usage
+```js
+const { addOrReplaceAddressOnList } = require('@vtex/delivery-packages/dist/address')
+
+addOrReplaceAddressOnList([
+  {
+    addressId: '-4556418741084',
+    addressType: 'residential',
+    receiverName: 'John Doe',
+    street: 'Rua Barão',
+    number: '2',
+    complement: null,
+    neighborhood: 'Botafogo',
+    postalCode: '22231-100',
+    city: 'Rio de Janeiro',
+    state: 'RJ',
+    country: 'BRA',
+    reference: null,
+    geoCoordinates: [],
+  }
+],
+{
+  addressId: '141125d',
+  addressType: 'pickup',
+  city: 'Rio de Janeiro',
+  complement: '',
+  country: 'BRA',
+  geoCoordinates: [-43.18080139160156, -22.96540069580078],
+  neighborhood: 'Copacabana',
+  number: '5',
+  postalCode: '22011050',
+  receiverName: 'auto auto',
+  reference: null,
+  state: 'RJ',
+  street: 'Rua General Azevedo Pimentel',
+})
+// -> [
+//   {
+//     addressId: '-4556418741084',
+//     addressType: 'residential',
+//     receiverName: 'John Doe',
+//     street: 'Rua Barão',
+//     number: '2',
+//     complement: null,
+//     neighborhood: 'Botafogo',
+//     postalCode: '22231-100',
+//     city: 'Rio de Janeiro',
+//     state: 'RJ',
+//     country: 'BRA',
+//     reference: null,
+//     geoCoordinates: [],
+//   },
+//   {
+//     addressId: '141125d',
+//     addressType: 'pickup',
+//     city: 'Rio de Janeiro',
+//     complement: '',
+//     country: 'BRA',
+//     geoCoordinates: [-43.18080139160156, -22.96540069580078],
+//     neighborhood: 'Copacabana',
+//     number: '5',
+//     postalCode: '22011050',
+//     receiverName: 'auto auto',
+//     reference: null,
+//     state: 'RJ',
+//     street: 'Rua General Azevedo Pimentel',
+//   }
+// ]
+
+addOrReplaceAddressTypeOnList([
+  {
+    addressId: '-4556418741084',
+    addressType: 'residential',
+    receiverName: 'John Doe',
+    street: 'Rua Barão',
+    number: '2',
+    complement: null,
+    neighborhood: 'Botafogo',
+    postalCode: '22231-100',
+    city: 'Rio de Janeiro',
+    state: 'RJ',
+    country: 'BRA',
+    reference: null,
+    geoCoordinates: [],
+  },
+  {
+    addressId: '1234',
+    addressType: 'pickup',
+    city: 'Rio de Janeiro',
+    complement: '',
+    country: 'BRA',
+    geoCoordinates: [-43.18080139160156, -22.96540069580078],
+    neighborhood: 'Copacabana',
+    number: '5',
+    postalCode: '22011050',
+    receiverName: 'auto auto',
+    reference: null,
+    state: 'RJ',
+    street: 'Rua General Azevedo Pimentel',
+  }
+], {
+  addressId: '1234',
+  addressType: 'pickup',
+  city: 'Rio de Janeiro',
+  complement: '',
+  country: 'BRA',
+  geoCoordinates: [],
+  neighborhood: 'Botafogo',
+  number: '300',
+  postalCode: '22250040',
+  receiverName: 'auto auto',
+  reference: null,
+  state: 'RJ',
+  street: 'Praia de botafogo',
+})
+// -> [
+//   {
+//     addressId: '-4556418741084',
+//     addressType: 'residential',
+//     receiverName: 'John Doe',
+//     street: 'Rua Barão',
+//     number: '2',
+//     complement: null,
+//     neighborhood: 'Botafogo',
+//     postalCode: '22231-100',
+//     city: 'Rio de Janeiro',
+//     state: 'RJ',
+//     country: 'BRA',
+//     reference: null,
+//     geoCoordinates: [],
+//   },
+//   {
+//     addressId: '1234',
+//     addressType: 'pickup',
+//     city: 'Rio de Janeiro',
+//     complement: '',
+//     country: 'BRA',
+//     geoCoordinates: [],
+//     neighborhood: 'Botafogo',
+//     number: '300',
+//     postalCode: '22250040',
+//     receiverName: 'auto auto',
+//     reference: null,
+//     state: 'RJ',
+//     street: 'Praia de botafogo',
+//   }
+// ]
+```
+
+**params:**
+- **addresses**
+Type: `Array<object>`
+An array which each item is an object containing all address fields like on selectedAddresses of orderForm
+- **newAddress**
+Type: `string`
+New address to be included on the list of addresses
+
+**returns:**
+- **new addresses**
+Type: `object`
+New list of addresses with the newAddress included
 
 ## Delivery Channel
 > @vtex/delivery-packages/dist/delivery-channel

--- a/README.md
+++ b/README.md
@@ -584,15 +584,15 @@ An array which each item is an object containing all address fields like on sele
 Type: `object`
 An object where each key is an address type and each value is an array of addresses grouped by each address type
 
-## addOrReplaceAddressOnList (addresses, newAddress)
+## addOrReplaceAddressTypeOnList (addresses, newAddress)
 
 Adds new address if the addressType of newAddress is not found or replace an existing address of that type
 
 ##### Usage
 ```js
-const { addOrReplaceAddressOnList } = require('@vtex/delivery-packages/dist/address')
+const { addOrReplaceAddressTypeOnList } = require('@vtex/delivery-packages/dist/address')
 
-addOrReplaceAddressOnList([
+addOrReplaceAddressTypeOnList([
   {
     addressId: '-4556418741084',
     addressType: 'residential',
@@ -657,7 +657,7 @@ addOrReplaceAddressOnList([
 //   }
 // ]
 
-addOrReplaceAddressOnList([
+addOrReplaceAddressTypeOnList([
   {
     addressId: '-4556418741084',
     addressType: 'residential',

--- a/README.md
+++ b/README.md
@@ -276,6 +276,20 @@ parcelify(order, { criteria: { seller: false } })
 
 This module provide a lot of helper functions besides parcelify, that are worth checking below.
 
+address:
+addAddressId
+findAddressIndex
+findAddress
+findAddressByPostalCode
+addOrReplaceAddressOnList
+addPickupPointAddresses
+
+sla:
+getPickupSelectedSlas
+
+shipping:
+getNewLogisticsMatchingSelectedAddresses
+
 ## Address
 > @vtex/delivery-packages/dist/address
 
@@ -1149,7 +1163,7 @@ selectDeliveryWindow(logisticsInfo, {
 **params:**
 - **logisticsInfo**
 Type: `Array<object>`
-The logisticsInfo like the one inside `orderForm` with `selectedSla` and `slas`
+The logisticsInfo like the one inside `orderForm.shippingData` with `selectedSla` and `slas`
 
 - **action**
 Type: `object`
@@ -1256,7 +1270,7 @@ getFirstScheduledDelivery(logisticsInfo, [
 **params:**
 - **logisticsInfo**
 Type: `Array<object>`
-The logisticsInfo like the one inside `orderForm` with `selectedSla` and `slas`
+The logisticsInfo like the one inside `orderForm.shippingData` with `selectedSla` and `slas`
 
 - **availableDeliveryWindows1**
 Type: `Array<object>`
@@ -1444,7 +1458,7 @@ getNewLogisticsInfo(logisticsInfo, 'Agendada', [
 **params:**
 - **logisticsInfo**
 Type: `Array<object>`
-The logisticsInfo like the one inside `orderForm` with `selectedSla` and `slas`
+The logisticsInfo like the one inside `orderForm.shippingData` with `selectedSla` and `slas`
 
 - **selectedSla**
 Type: `string`
@@ -1568,7 +1582,7 @@ getNewLogisticsInfoWithSelectedScheduled(logisticsInfo)
 **params:**
 - **logisticsInfo**
 Type: `Array<object>`
-The logisticsInfo like the one inside `orderForm` with `selectedSla` and `slas`
+The logisticsInfo like the one inside `orderForm.shippingData` with `selectedSla` and `slas`
 
 **returns:**
 - **new logisticsInfo**
@@ -1707,7 +1721,7 @@ getNewLogisticsInfoWithScheduledDeliveryChoice(logisticsInfo, { selectedSla: 'Ag
 **params:**
 - **logisticsInfo**
 Type: `Array<object>`
-The logisticsInfo like the one inside `orderForm` with `selectedSla` and `slas`
+The logisticsInfo like the one inside `orderForm.shippingData` with `selectedSla` and `slas`
 - **scheduledDeliveryChoice**
 Type: `object`
 An object like `{ selectedSla, deliveryWindow }` saying what sla and deliveryWindow to choose the delivery
@@ -1803,7 +1817,7 @@ filterLogisticsInfo(logisticsInfo, { items }, keepSize)
 **params:**
 - **logisticsInfo**
 Type: `Array<object>`
-The logisticsInfo like the one inside `orderForm` with `selectedSla` and `slas`
+The logisticsInfo like the one inside `orderForm.shippingData` with `selectedSla` and `slas`
 - **filters**
 Type: `object`
 An object like `{ items: [{ index or itemIndex: number }, ...], }` saying what items to filter on logisticsInfo
@@ -1815,6 +1829,169 @@ Flag to inform if the missing items are maintained on the new array as `null` va
 - **new logisticsInfo**
 Type: `Array<object>`
 New logisticsInfo filtered by the `filters` param and with the size according to `keepSize` param
+
+### getNewLogisticsMatchingSelectedAddresses (logisticsInfo, selectedAddresses)
+
+Get new logisticsInfo and selectedAddresses making sure all pickup addresses that are on a selectedSla are included on selectedAddresses list and then making sure all logisticsInfo items have addressIds matching the ones on selectedAddresses.
+
+##### Usage
+```js
+const { getNewLogisticsMatchingSelectedAddresses } = require('@vtex/delivery-packages/dist/shipping')
+
+const logisticsInfo = [
+  {
+    // You can pass all the properties of the logisticsInfo
+    "addressId": "-4556418741084",
+    "selectedSla": "MeuPickupPoint",
+    "selectedDeliveryChannel": "pickup-in-point",
+    "itemIndex": 0,
+    "slas": [
+      {
+      	"id": "MeuPickupPoint",
+      	"deliveryChannel": "pickup-in-point",
+      	"name": "VTEX RJ (1b4e9b2)",
+      	"shippingEstimate": "0bd",
+      	"price": 0,
+      	"pickupPointId": "1_1b4e9b2",
+      	"pickupStoreInfo": {
+      		"isPickupStore": true,
+      		"friendlyName": "VTEX RJ",
+      		"address": {
+      			"addressType": "pickup",
+      			"receiverName": null,
+      			"addressId": "1b4e9b2",
+      			"postalCode": "22250040",
+      			"city": "Rio de Janeiro",
+      			"state": "RJ",
+      			"country": "BRA",
+      			"street": "Praia de Botafogo",
+      			"number": "300",
+      			"neighborhood": "Botafogo",
+      			"complement": "",
+      			"reference": null,
+      			"geoCoordinates": [-43.1822662, -22.9459858]
+      		}
+      	}
+      }
+    ]
+  },
+  {
+    "addressId": null,
+    "selectedSla": "Normal",
+    "selectedDeliveryChannel": "delivery",
+    "itemIndex": 1,
+    "slas": [
+      // You can pass all the properties of the sla
+      { "id": "Normal", "deliveryChannel": "delivery" }
+    ]
+  }
+]
+
+const selectedAddresses = [{
+  "addressId": "-4556418741084",
+  "addressType": "residential",
+  "receiverName": "John Doe",
+  "street": "Rua Barão",
+  "number": "2",
+  "complement": null,
+  "neighborhood": "Botafogo",
+  "postalCode": "22231-100",
+  "city": "Rio de Janeiro",
+  "state": "RJ",
+  "country": "BRA",
+  "reference": null,
+  "geoCoordinates": [],
+}]
+
+getNewLogisticsMatchingSelectedAddresses(logisticsInfo, selectedAddresses)
+// -> {
+//   logisticsInfo: [{
+//     "addressId": "1b4e9b2",
+//     "selectedSla": "MeuPickupPoint",
+//     "selectedDeliveryChannel": "pickup-in-point",
+//     "itemIndex": 0,
+//     "slas": [
+//       {
+//       	"id": "MeuPickupPoint",
+//       	"deliveryChannel": "pickup-in-point",
+//       	"name": "VTEX RJ (1b4e9b2)",
+//       	"shippingEstimate": "0bd",
+//       	"price": 0,
+//       	"pickupPointId": "1_1b4e9b2",
+//       	"pickupStoreInfo": {
+//       		"isPickupStore": true,
+//       		"friendlyName": "VTEX RJ",
+//       		"address": {
+//       			"addressType": "pickup",
+//       			"receiverName": null,
+//       			"addressId": "1b4e9b2",
+//       			"postalCode": "22250040",
+//       			"city": "Rio de Janeiro",
+//       			"state": "RJ",
+//       			"country": "BRA",
+//       			"street": "Praia de Botafogo",
+//       			"number": "300",
+//       			"neighborhood": "Botafogo",
+//       			"complement": "",
+//       			"reference": null,
+//       			"geoCoordinates": [-43.1822662, -22.9459858]
+//       		}
+//       	}
+//       }
+//     ]
+//   },
+//   {
+//     "addressId": "-4556418741084",
+//     "selectedSla": "Normal",
+//     "selectedDeliveryChannel": "delivery",
+//     "itemIndex": 1,
+//     "slas": [
+//       { "id": "Normal", "deliveryChannel": "delivery" }
+//     ]
+//   }],
+//   selectedAddresses: [{
+//     "addressId": "-4556418741084",
+//     "addressType": "residential",
+//     "receiverName": "John Doe",
+//     "street": "Rua Barão",
+//     "number": "2",
+//     "complement": null,
+//     "neighborhood": "Botafogo",
+//     "postalCode": "22231-100",
+//     "city": "Rio de Janeiro",
+//     "state": "RJ",
+//     "country": "BRA",
+//     "reference": null,
+//     "geoCoordinates": [],
+//   }, {
+//     "addressType": "pickup",
+//     "receiverName": null,
+//     "addressId": "1b4e9b2",
+//     "postalCode": "22250040",
+//     "city": "Rio de Janeiro",
+//     "state": "RJ",
+//     "country": "BRA",
+//     "street": "Praia de Botafogo",
+//     "number": "300",
+//     "neighborhood": "Botafogo",
+//     "complement": "",
+//     "reference": null,
+//     "geoCoordinates": [-43.1822662, -22.9459858]
+//   }]
+// }
+```
+
+**params:**
+- **logisticsInfo**
+Type: `Array<object>`
+The logisticsInfo like the one inside `orderForm.shippingData` with `selectedSla` and `slas`
+- **selectedAddresses**
+Type: `Array<object>`
+The selectedAddresses like the one inside `orderForm.shippingData` with address objects that are related to the order
+**returns:**
+- **new object with new logisticsInfo and new selectedAddresses**
+Type: `{ logisticsInfo: Array<object>, selectedAddresses: Array<object> }`
+New logisticsInfo and selectedAddresses with matching addressIds and with all pickup addresses included
 
 ## SLA
 > @vtex/delivery-packages/dist/sla
@@ -2084,7 +2261,7 @@ getSelectedSlas(logisticsInfo)
 **params:**
 - **logisticsInfo**
 Type: `Array<object>`
-The logisticsInfo like the one inside `orderForm` with `selectedSla` and `slas`
+The logisticsInfo like the one inside `orderForm.shippingData` with `selectedSla` and `slas`
 
 **returns:**
 - **selectedSlas**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/delivery-packages",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/address.js
+++ b/src/address.js
@@ -105,7 +105,7 @@ export function groupByAddressType(addresses) {
 }
 
 export function addOrReplaceAddressOnList(addresses, newAddress) {
-  if (!addresses || addresses.length === 0 || !newAddress) {
+  if (!addresses || !newAddress) {
     return addresses
   }
 
@@ -127,24 +127,20 @@ export function addOrReplaceAddressOnList(addresses, newAddress) {
 }
 
 export function addPickupPointAddresses(addresses, pickupSlas) {
-  if (
-    !addresses ||
-    addresses.length === 0 ||
-    !pickupSlas ||
-    pickupSlas.length === 0
-  ) {
+  if (!addresses || !pickupSlas || pickupSlas.length === 0) {
     return addresses
   }
 
   return pickupSlas.reduce(
     (newAddresses, pickupSla) => {
-      const searchAddress = findAddress(addresses, searchAddress)
+      const pickupAddress = getPickupAddress(pickupSla)
+      const searchAddress = findAddress(addresses, pickupAddress)
       if (searchAddress) {
         return newAddresses
       }
 
       const newAddress = {
-        ...getPickupAddress(pickupSla),
+        ...pickupAddress,
         addressType: SEARCH,
       }
       return addOrReplaceAddressOnList(newAddresses, newAddress)

--- a/src/address.js
+++ b/src/address.js
@@ -5,6 +5,7 @@ import {
   COMMERCIAL,
   GIFT_REGISTRY,
 } from './constants'
+import uuid from './uuid'
 
 /** PRIVATE **/
 
@@ -41,16 +42,6 @@ export function getPickupAddress(pickupSla) {
   )
 }
 
-export function findAddress(addresses, searchAddress) {
-  if (!addresses || addresses.length === 0 || !searchAddress) {
-    return null
-  }
-
-  return addresses.find(
-    address => address.addressId === searchAddress.addressId
-  )
-}
-
 /** PUBLIC **/
 
 export function isAddressComplete(address) {
@@ -75,6 +66,30 @@ export function isDeliveryAddress(address) {
     address.addressType === COMMERCIAL ||
     address.addressType === GIFT_REGISTRY
   )
+}
+
+export function addAddressId(address) {
+  if (!address || address.addressId) {
+    return address
+  }
+  return {
+    ...address,
+    addressId: uuid(),
+  }
+}
+
+export function findAddress(addresses, searchAddress, prop = 'addressId') {
+  if (!addresses || addresses.length === 0 || !searchAddress) {
+    return null
+  }
+
+  return (
+    addresses.find(address => address[prop] === searchAddress[prop]) || null
+  )
+}
+
+export function findAddressByPostalCode(addresses, searchAddress) {
+  return findAddress(addresses, searchAddress, 'postalCode')
 }
 
 export function getDeliveryAvailableAddresses(addresses) {

--- a/src/address.js
+++ b/src/address.js
@@ -18,6 +18,39 @@ export function getFirstAddressForType(addresses, addressType) {
   return groupAddresses && groupAddresses.length > 0 ? groupAddresses[0] : null
 }
 
+export function getFirstAddressOnAnyOfTheseTypes(addresses, addressesTypes) {
+  return addressesTypes.reduce((address, addressType) => {
+    return address || getFirstAddressForType(addresses, addressType)
+  }, null)
+}
+
+export function getFirstAddressForDelivery(addresses) {
+  return getFirstAddressOnAnyOfTheseTypes(addresses, [
+    RESIDENTIAL,
+    COMMERCIAL,
+    GIFT_REGISTRY,
+  ])
+}
+
+export function getPickupAddress(pickupSla) {
+  return (
+    (pickupSla &&
+      pickupSla.pickupStoreInfo &&
+      pickupSla.pickupStoreInfo.address) ||
+    null
+  )
+}
+
+export function findAddress(addresses, searchAddress) {
+  if (!addresses || addresses.length === 0 || !searchAddress) {
+    return null
+  }
+
+  return addresses.find(
+    address => address.addressId === searchAddress.addressId
+  )
+}
+
 /** PUBLIC **/
 
 export function isAddressComplete(address) {
@@ -91,4 +124,31 @@ export function addOrReplaceAddressOnList(addresses, newAddress) {
   }
 
   return newAddresses
+}
+
+export function addPickupPointAddresses(addresses, pickupSlas) {
+  if (
+    !addresses ||
+    addresses.length === 0 ||
+    !pickupSlas ||
+    pickupSlas.length === 0
+  ) {
+    return addresses
+  }
+
+  return pickupSlas.reduce(
+    (newAddresses, pickupSla) => {
+      const searchAddress = findAddress(addresses, searchAddress)
+      if (searchAddress) {
+        return newAddresses
+      }
+
+      const newAddress = {
+        ...getPickupAddress(pickupSla),
+        addressType: SEARCH,
+      }
+      return addOrReplaceAddressOnList(newAddresses, newAddress)
+    },
+    [...addresses]
+  )
 }

--- a/src/address.js
+++ b/src/address.js
@@ -78,6 +78,14 @@ export function addAddressId(address) {
   }
 }
 
+export function findAddressIndex(addresses, searchAddress, prop = 'addressId') {
+  if (!addresses || addresses.length === 0 || !searchAddress) {
+    return -1
+  }
+
+  return addresses.findIndex(address => address[prop] === searchAddress[prop])
+}
+
 export function findAddress(addresses, searchAddress, prop = 'addressId') {
   if (!addresses || addresses.length === 0 || !searchAddress) {
     return null
@@ -119,7 +127,7 @@ export function groupByAddressType(addresses) {
   }, {})
 }
 
-export function addOrReplaceAddressOnList(addresses, newAddress) {
+export function addOrReplaceAddressTypeOnList(addresses, newAddress) {
   if (!addresses || !newAddress) {
     return addresses
   }
@@ -133,6 +141,27 @@ export function addOrReplaceAddressOnList(addresses, newAddress) {
   }
 
   const addressIndex = address.index
+  newAddresses[addressIndex] = {
+    ...newAddresses[addressIndex],
+    ...newAddress,
+  }
+
+  return newAddresses
+}
+
+export function addOrReplaceAddressOnList(addresses, newAddress) {
+  if (!addresses || !newAddress) {
+    return addresses
+  }
+
+  const newAddresses = [...addresses]
+
+  const addressIndex = findAddressIndex(newAddresses, newAddress)
+
+  if (addressIndex === -1) {
+    return [...newAddresses, newAddress]
+  }
+
   newAddresses[addressIndex] = {
     ...newAddresses[addressIndex],
     ...newAddress,
@@ -158,6 +187,7 @@ export function addPickupPointAddresses(addresses, pickupSlas) {
         ...pickupAddress,
         addressType: SEARCH,
       }
+
       return addOrReplaceAddressOnList(newAddresses, newAddress)
     },
     [...addresses]

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,8 +1,10 @@
-if (!Array.prototype.find) {
+if (!Array.prototype.findIndex) {
   // eslint-disable-next-line no-extend-native
-  Array.prototype.find = function(predicate) {
+  Array.prototype.findIndex = function(predicate) {
     if (this === null) {
-      throw new TypeError('Array.prototype.find called on null or undefined')
+      throw new TypeError(
+        'Array.prototype.findIndex called on null or undefined'
+      )
     }
     if (typeof predicate !== 'function') {
       throw new TypeError('predicate must be a function')
@@ -15,10 +17,25 @@ if (!Array.prototype.find) {
     for (var i = 0; i < length; i++) {
       value = list[i]
       if (predicate.call(thisArg, value, i, list)) {
-        return value
+        return i
       }
     }
-    return undefined
+    return -1
+  }
+}
+
+if (!Array.prototype.find) {
+  // eslint-disable-next-line no-extend-native
+  Array.prototype.find = function(predicate) {
+    if (this === null) {
+      throw new TypeError('Array.prototype.find called on null or undefined')
+    }
+    if (typeof predicate !== 'function') {
+      throw new TypeError('predicate must be a function')
+    }
+    var list = Object(this)
+    var i = list.findIndex(predicate)
+    return list[i]
   }
 }
 

--- a/src/shipping.js
+++ b/src/shipping.js
@@ -4,7 +4,7 @@ import {
   getPickupAddress,
   getFirstAddressForDelivery,
 } from './address'
-import { isPickup, isDelivery } from './delivery-channel'
+import { isPickup, isDelivery, getDeliveryChannel } from './delivery-channel'
 import {
   hasDeliveryWindows,
   getSelectedSla,
@@ -108,21 +108,30 @@ export function replaceAddressIdOnLogisticsInfo(
   logisticsInfo,
   selectedAddresses
 ) {
+  if (
+    !logisticsInfo ||
+    logisticsInfo.length === 0 ||
+    !selectedAddresses ||
+    selectedAddresses.length === 0
+  ) {
+    return logisticsInfo
+  }
+
   return logisticsInfo.map(li => {
     const selectedSlaObj = getSlaObj(li.slas, li.selectedSla)
-    if (!selectedSlaObj || !selectedSlaObj.selectedDeliveryChannel) {
+    const deliveryChannel = getDeliveryChannel(selectedSlaObj)
+
+    if (!selectedSlaObj || !deliveryChannel) {
       return li
     }
 
-    const { selectedDeliveryChannel } = selectedSlaObj
-
     let selectedAddress = null
 
-    if (isPickup(selectedDeliveryChannel)) {
+    if (isPickup(deliveryChannel)) {
       selectedAddress = getPickupAddress(selectedSlaObj)
     }
 
-    if (isDelivery(selectedDeliveryChannel)) {
+    if (isDelivery(deliveryChannel)) {
       selectedAddress = getFirstAddressForDelivery(selectedAddresses)
     }
 

--- a/src/shipping.js
+++ b/src/shipping.js
@@ -59,7 +59,9 @@ export function getLogisticsInfoData(params) {
 
 function getPickupFriendlyName({ itemIndex, logisticsInfo }) {
   const sla = getSelectedSla({ itemIndex, logisticsInfo })
-  return sla && sla.pickupStoreInfo ? sla.pickupStoreInfo.friendlyName : null
+  return sla && sla.pickupStoreInfo && sla.pickupStoreInfo.friendlyName
+    ? sla.pickupStoreInfo.friendlyName
+    : null
 }
 
 function getAddress({ itemIndex, logisticsInfo, selectedAddresses }) {
@@ -169,24 +171,16 @@ export function getNewLogisticsInfo(
   })
 }
 
-export function getNewLogisticsAndSelectedAddresses(
+export function getNewLogisticsMatchingSelectedAddresses(
   logisticsInfo,
-  selectedSla,
-  selectedAddresses,
-  availableDeliveryWindows = null
+  selectedAddresses
 ) {
-  let newLogisticsInfo = getNewLogisticsInfo(
-    logisticsInfo,
-    selectedSla,
-    availableDeliveryWindows
-  )
-
   const newSelectedAddresses = addPickupPointAddresses(
     selectedAddresses,
     getPickupSelectedSlas(logisticsInfo)
   )
 
-  newLogisticsInfo = replaceAddressIdOnLogisticsInfo(
+  const newLogisticsInfo = replaceAddressIdOnLogisticsInfo(
     newLogisticsInfo,
     newSelectedAddresses
   )

--- a/src/shipping.js
+++ b/src/shipping.js
@@ -204,7 +204,7 @@ export function getNewLogisticsMatchingSelectedAddresses(
   }
 
   const newLogisticsInfo = replaceAddressIdOnLogisticsInfo(
-    newLogisticsInfo,
+    logisticsInfo,
     newSelectedAddresses
   )
 

--- a/src/shipping.js
+++ b/src/shipping.js
@@ -184,10 +184,24 @@ export function getNewLogisticsMatchingSelectedAddresses(
   logisticsInfo,
   selectedAddresses
 ) {
+  if (!logisticsInfo || logisticsInfo.length === 0) {
+    return {
+      logisticsInfo: [],
+      selectedAddresses,
+    }
+  }
+
   const newSelectedAddresses = addPickupPointAddresses(
     selectedAddresses,
     getPickupSelectedSlas(logisticsInfo)
   )
+
+  if (!newSelectedAddresses || newSelectedAddresses.length === 0) {
+    return {
+      logisticsInfo,
+      selectedAddresses: [],
+    }
+  }
 
   const newLogisticsInfo = replaceAddressIdOnLogisticsInfo(
     newLogisticsInfo,

--- a/src/sla.js
+++ b/src/sla.js
@@ -110,7 +110,7 @@ export function filterPickupTypeFromSlas(slas) {
   }
 
   return slas.filter(
-    sla => sla.pickupStoreInfo && sla.pickupStoreInfo.isPickupStore
+    sla => sla && sla.pickupStoreInfo && sla.pickupStoreInfo.isPickupStore
   )
 }
 

--- a/src/sla.js
+++ b/src/sla.js
@@ -104,6 +104,16 @@ export function excludePickupTypeFromSlas(slas) {
   )
 }
 
+export function filterPickupTypeFromSlas(slas) {
+  if (!slas || slas.length === 0) {
+    return []
+  }
+
+  return slas.filter(
+    sla => sla.pickupStoreInfo && sla.pickupStoreInfo.isPickupStore
+  )
+}
+
 export function getSelectedSlas(logisticsInfo) {
   if (!logisticsInfo || logisticsInfo.length === 0) {
     return []
@@ -122,4 +132,9 @@ export function getSelectedSlas(logisticsInfo) {
       }
       : null
   })
+}
+
+export function getPickupSelectedSlas(logisticsInfo) {
+  const selectedSlas = getSelectedSlas(logisticsInfo)
+  return filterPickupTypeFromSlas(selectedSlas)
 }

--- a/src/uuid.js
+++ b/src/uuid.js
@@ -1,0 +1,12 @@
+function S4() {
+  return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1)
+}
+
+function uuid() {
+  return `${S4() + S4()}-${S4()}-4${S4().substr(
+    0,
+    3
+  )}-${S4()}-${S4()}${S4()}${S4()}`.toLowerCase()
+}
+
+export default uuid

--- a/tests/address.test.js
+++ b/tests/address.test.js
@@ -6,6 +6,7 @@ import {
   getDeliveryAvailableAddresses,
   groupByAddressType,
   getFirstAddressForType,
+  getPickupAddress,
   addOrReplaceAddressOnList,
   addPickupPointAddresses,
   addAddressId,
@@ -267,6 +268,31 @@ describe('Address', () => {
       expect(address1).toEqual(pickupAddress)
       expect(address2).toEqual(residentialAddress1)
       expect(address3).toEqual(searchAddress)
+    })
+  })
+
+  describe('getPickupAddress', () => {
+    it('should be empty if empty params are passed', () => {
+      const address1 = getPickupAddress()
+      const address2 = getPickupAddress(null)
+
+      expect(address1).toBeNull()
+      expect(address2).toBeNull()
+    })
+
+    it('should return null if address not found', () => {
+      const address1 = getPickupAddress(slas.normalSla)
+
+      expect(address1).toBeNull()
+    })
+
+    it('should get correct address if sla contains address', () => {
+      const pickupSla = slas.pickupSla
+      const expectedAddress = addresses.pickupPointAddress
+
+      const address1 = getPickupAddress(pickupSla)
+
+      expect(address1).toEqual(expectedAddress)
     })
   })
 

--- a/tests/address.test.js
+++ b/tests/address.test.js
@@ -12,6 +12,7 @@ import {
   addAddressId,
   findAddress,
   findAddressByPostalCode,
+  getFirstAddressForDelivery,
 } from '../src/address'
 import { PICKUP, SEARCH, RESIDENTIAL } from '../src/constants'
 
@@ -455,6 +456,7 @@ describe('Address', () => {
       const searchAddress = addresses.searchAddress
       const residentialAddress1 = addresses.residentialAddress
       const addresses1 = [pickupAddress, residentialAddress1]
+
       const address1 = findAddress(addresses1, searchAddress)
 
       expect(address1).toBeNull()
@@ -464,6 +466,7 @@ describe('Address', () => {
       const pickupAddress = addresses.pickupPointAddress
       const residentialAddress1 = addresses.residentialAddress
       const addresses1 = [pickupAddress, residentialAddress1]
+
       const address1 = findAddress(addresses1, pickupAddress)
 
       expect(address1).toEqual(pickupAddress)
@@ -484,6 +487,7 @@ describe('Address', () => {
       const searchAddress = addresses.searchAddress
       const residentialAddress1 = addresses.residentialAddress
       const addresses1 = [pickupAddress, residentialAddress1]
+
       const address1 = findAddressByPostalCode(addresses1, searchAddress)
 
       expect(address1).toBeNull()
@@ -493,6 +497,7 @@ describe('Address', () => {
       const pickupAddress = addresses.pickupPointAddress
       const residentialAddress1 = addresses.residentialAddress
       const addresses1 = [pickupAddress, residentialAddress1]
+
       const address1 = findAddressByPostalCode(addresses1, pickupAddress)
 
       expect(address1).toEqual(pickupAddress)
@@ -503,10 +508,41 @@ describe('Address', () => {
       const residentialAddress1 = addresses.residentialAddress
       const samePostalCodeAddress = addresses.commercialAddress
       const addresses1 = [pickupAddress, residentialAddress1]
+
       const address1 = findAddressByPostalCode(
         addresses1,
         samePostalCodeAddress
       )
+
+      expect(address1).toEqual(residentialAddress1)
+    })
+  })
+
+  describe('getFirstAddressForDelivery', () => {
+    it('should be empty if empty params are passed', () => {
+      const address1 = getFirstAddressForDelivery()
+      const address2 = getFirstAddressForDelivery([])
+
+      expect(address1).toBeNull()
+      expect(address2).toBeNull()
+    })
+
+    it('shouldnt find address if no delivery address is on list', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
+      const addresses1 = [pickupAddress, searchAddress]
+
+      const address1 = getFirstAddressForDelivery(addresses1)
+
+      expect(address1).toBeNull()
+    })
+
+    it('should find delivery address on list', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const addresses1 = [pickupAddress, residentialAddress1]
+
+      const address1 = getFirstAddressForDelivery(addresses1)
 
       expect(address1).toEqual(residentialAddress1)
     })

--- a/tests/address.test.js
+++ b/tests/address.test.js
@@ -7,6 +7,7 @@ import {
   groupByAddressType,
   getFirstAddressForType,
   getPickupAddress,
+  addOrReplaceAddressTypeOnList,
   addOrReplaceAddressOnList,
   addPickupPointAddresses,
   addAddressId,
@@ -297,6 +298,64 @@ describe('Address', () => {
     })
   })
 
+  describe('addOrReplaceAddressTypeOnList', () => {
+    it('should be empty if empty params are passed', () => {
+      const addresses1 = addOrReplaceAddressTypeOnList()
+      const addresses2 = addOrReplaceAddressTypeOnList([], null)
+
+      expect(addresses1).toBeUndefined()
+      expect(addresses2).toEqual([])
+    })
+
+    it('should add address on empty address list', () => {
+      const residentialAddress1 = addresses.residentialAddress
+      const addresses1 = []
+      const expectedAddresses1 = [...addresses1, residentialAddress1]
+
+      const resultAddresses1 = addOrReplaceAddressTypeOnList(
+        addresses1,
+        residentialAddress1
+      )
+
+      expect(resultAddresses1).toEqual(expectedAddresses1)
+    })
+
+    it('should add address', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const addresses1 = [pickupAddress, searchAddress]
+      const expectedAddresses1 = [...addresses1, residentialAddress1]
+
+      const resultAddresses1 = addOrReplaceAddressTypeOnList(
+        addresses1,
+        residentialAddress1
+      )
+
+      expect(resultAddresses1).toEqual(expectedAddresses1)
+    })
+
+    it('should replace address with all info', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const residentialAddress2 = {
+        ...residentialAddress1,
+        receiverName: 'Other Doe',
+      }
+      const baseAddresses = [pickupAddress, searchAddress]
+      const addresses1 = [...baseAddresses, residentialAddress1]
+      const expectedAddresses1 = [...baseAddresses, residentialAddress2]
+
+      const resultAddresses1 = addOrReplaceAddressTypeOnList(
+        addresses1,
+        residentialAddress2
+      )
+
+      expect(resultAddresses1).toEqual(expectedAddresses1)
+    })
+  })
+
   describe('addOrReplaceAddressOnList', () => {
     it('should be empty if empty params are passed', () => {
       const addresses1 = addOrReplaceAddressOnList()
@@ -334,17 +393,33 @@ describe('Address', () => {
       expect(resultAddresses1).toEqual(expectedAddresses1)
     })
 
-    it('should replace address with all info', () => {
+    it('should replace addresses with unique id', () => {
       const pickupAddress = addresses.pickupPointAddress
       const searchAddress = addresses.searchAddress
       const residentialAddress1 = addresses.residentialAddress
       const residentialAddress2 = {
-        ...addresses.residentialAddress,
+        ...residentialAddress1,
         receiverName: 'Other Doe',
       }
       const baseAddresses = [pickupAddress, searchAddress]
       const addresses1 = [...baseAddresses, residentialAddress1]
       const expectedAddresses1 = [...baseAddresses, residentialAddress2]
+
+      const resultAddresses1 = addOrReplaceAddressOnList(
+        addresses1,
+        residentialAddress2
+      )
+
+      expect(resultAddresses1).toEqual(expectedAddresses1)
+    })
+
+    it('should add multiple addresses of same type if different ids', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const residentialAddress2 = addresses.residentialAddress2
+      const addresses1 = [pickupAddress, searchAddress, residentialAddress1]
+      const expectedAddresses1 = [...addresses1, residentialAddress2]
 
       const resultAddresses1 = addOrReplaceAddressOnList(
         addresses1,

--- a/tests/address.test.js
+++ b/tests/address.test.js
@@ -8,6 +8,9 @@ import {
   getFirstAddressForType,
   addOrReplaceAddressOnList,
   addPickupPointAddresses,
+  addAddressId,
+  findAddress,
+  findAddressByPostalCode,
 } from '../src/address'
 import { PICKUP, SEARCH, RESIDENTIAL } from '../src/constants'
 
@@ -337,9 +340,7 @@ describe('Address', () => {
     it('should add address but with search type on empty addresses', () => {
       const pickupAddress = addresses.pickupPointAddress
       const addresses1 = []
-      const pickupSlas = [
-        slas.pickupSla,
-      ]
+      const pickupSlas = [slas.pickupSla]
       const expectedAddresses = [
         {
           ...pickupAddress,
@@ -356,9 +357,7 @@ describe('Address', () => {
       const pickupAddress = addresses.pickupPointAddress
       const residentialAddress1 = addresses.residentialAddress
       const addresses1 = [residentialAddress1]
-      const pickupSlas = [
-        slas.pickupSla,
-      ]
+      const pickupSlas = [slas.pickupSla]
       const expectedAddresses = [
         ...addresses1,
         {
@@ -376,16 +375,114 @@ describe('Address', () => {
       const pickupAddress = addresses.pickupPointAddress
       const residentialAddress1 = addresses.residentialAddress
       const addresses1 = [pickupAddress, residentialAddress1]
-      const pickupSlas = [
-        slas.pickupSla,
-      ]
-      const expectedAddresses = [
-        ...addresses1,
-      ]
+      const pickupSlas = [slas.pickupSla]
+      const expectedAddresses = [...addresses1]
 
       const newAddresses = addPickupPointAddresses(addresses1, pickupSlas)
 
       expect(newAddresses).toEqual(expectedAddresses)
+    })
+  })
+
+  describe('addAddressId', () => {
+    it('should be empty if empty params are passed', () => {
+      const address1 = addAddressId()
+      const address2 = addAddressId(null)
+
+      expect(address1).toBeUndefined()
+      expect(address2).toBeNull()
+    })
+
+    it('should add addressId on empty object', () => {
+      const address1 = addAddressId({})
+
+      expect(address1.addressId).toBeTruthy()
+    })
+
+    it('should add addressId on incomplete address', () => {
+      const address1 = addAddressId({
+        ...addresses.residentialAddress.addressId,
+        addressId: null,
+      })
+
+      expect(address1.addressId).toBeTruthy()
+    })
+
+    it('shouldnt add addressId on complete address', () => {
+      const address1 = addAddressId(addresses.residentialAddress)
+
+      expect(address1.addressId).toEqual(addresses.residentialAddress.addressId)
+    })
+  })
+
+  describe('findAddress', () => {
+    it('should be empty if empty params are passed', () => {
+      const address1 = findAddress()
+      const address2 = findAddress([], null)
+
+      expect(address1).toBeNull()
+      expect(address2).toBeNull()
+    })
+
+    it('shouldnt find address not on list', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const addresses1 = [pickupAddress, residentialAddress1]
+      const address1 = findAddress(addresses1, searchAddress)
+
+      expect(address1).toBeNull()
+    })
+
+    it('should find address on list', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const addresses1 = [pickupAddress, residentialAddress1]
+      const address1 = findAddress(addresses1, pickupAddress)
+
+      expect(address1).toEqual(pickupAddress)
+    })
+  })
+
+  describe('findAddressByPostalCode', () => {
+    it('should be empty if empty params are passed', () => {
+      const address1 = findAddressByPostalCode()
+      const address2 = findAddressByPostalCode([], null)
+
+      expect(address1).toBeNull()
+      expect(address2).toBeNull()
+    })
+
+    it('shouldnt find address not on list', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const addresses1 = [pickupAddress, residentialAddress1]
+      const address1 = findAddressByPostalCode(addresses1, searchAddress)
+
+      expect(address1).toBeNull()
+    })
+
+    it('should find address on list', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const addresses1 = [pickupAddress, residentialAddress1]
+      const address1 = findAddressByPostalCode(addresses1, pickupAddress)
+
+      expect(address1).toEqual(pickupAddress)
+    })
+
+    it('should find postalcode on list', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const samePostalCodeAddress = addresses.commercialAddress
+      const addresses1 = [pickupAddress, residentialAddress1]
+      const address1 = findAddressByPostalCode(
+        addresses1,
+        samePostalCodeAddress
+      )
+
+      expect(address1).toEqual(residentialAddress1)
     })
   })
 })

--- a/tests/address.test.js
+++ b/tests/address.test.js
@@ -7,10 +7,11 @@ import {
   groupByAddressType,
   getFirstAddressForType,
   addOrReplaceAddressOnList,
+  addPickupPointAddresses,
 } from '../src/address'
 import { PICKUP, SEARCH, RESIDENTIAL } from '../src/constants'
 
-import { addresses } from './mockGenerator'
+import { slas, addresses } from './mockGenerator'
 
 describe('Address', () => {
   describe('isAddressComplete', () => {
@@ -149,8 +150,8 @@ describe('Address', () => {
         ...addresses.residentialAddress,
         street: null,
       }
-      const pickupAdress = addresses.pickupPointAddress
-      const searchAdress = addresses.searchAddress
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
       const residentialAddress1 = addresses.residentialAddress
       const residentialAddress2 = {
         ...addresses.residentialAddress,
@@ -161,9 +162,9 @@ describe('Address', () => {
       const addresses1 = getDeliveryAvailableAddresses([
         incompleteAddress1,
         residentialAddress1,
-        pickupAdress,
+        pickupAddress,
         residentialAddress2,
-        searchAdress,
+        searchAddress,
       ])
 
       expect(addresses1).toEqual([residentialAddress1, residentialAddress2])
@@ -180,24 +181,24 @@ describe('Address', () => {
     })
 
     it('should group by addressType', () => {
-      const pickupAdress = addresses.pickupPointAddress
+      const pickupAddress = addresses.pickupPointAddress
       const residentialAddress = addresses.residentialAddress
       const expectedGroups1 = {
-        [PICKUP]: [pickupAdress],
+        [PICKUP]: [pickupAddress],
         [RESIDENTIAL]: [residentialAddress],
       }
 
       const addressGroups1 = groupByAddressType([
         residentialAddress,
-        pickupAdress,
+        pickupAddress,
       ])
 
       expect(addressGroups1).toEqual(expectedGroups1)
     })
 
     it('should group all types by addressType', () => {
-      const pickupAdress = addresses.pickupPointAddress
-      const searchAdress = addresses.searchAddress
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
       const residentialAddress1 = addresses.residentialAddress
       const residentialAddress2 = {
         ...addresses.residentialAddress,
@@ -205,16 +206,16 @@ describe('Address', () => {
         receiverName: 'Other Doe',
       }
       const expectedGroups1 = {
-        [PICKUP]: [pickupAdress],
-        [SEARCH]: [searchAdress],
+        [PICKUP]: [pickupAddress],
+        [SEARCH]: [searchAddress],
         [RESIDENTIAL]: [residentialAddress1, residentialAddress2],
       }
 
       const addressGroups1 = groupByAddressType([
         residentialAddress1,
-        pickupAdress,
+        pickupAddress,
         residentialAddress2,
-        searchAdress,
+        searchAddress,
       ])
 
       expect(addressGroups1).toEqual(expectedGroups1)
@@ -231,9 +232,9 @@ describe('Address', () => {
     })
 
     it('should return null if address not found', () => {
-      const pickupAdress = addresses.pickupPointAddress
-      const searchAdress = addresses.searchAddress
-      const addresses1 = [pickupAdress, searchAdress]
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
+      const addresses1 = [pickupAddress, searchAddress]
 
       const address1 = getFirstAddressForType(addresses1, RESIDENTIAL)
 
@@ -241,8 +242,8 @@ describe('Address', () => {
     })
 
     it('should get correct address by addressType', () => {
-      const pickupAdress = addresses.pickupPointAddress
-      const searchAdress = addresses.searchAddress
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
       const residentialAddress1 = addresses.residentialAddress
       const residentialAddress2 = {
         ...addresses.residentialAddress,
@@ -251,18 +252,18 @@ describe('Address', () => {
       }
       const addresses1 = [
         residentialAddress1,
-        pickupAdress,
+        pickupAddress,
         residentialAddress2,
-        searchAdress,
+        searchAddress,
       ]
 
       const address1 = getFirstAddressForType(addresses1, PICKUP)
       const address2 = getFirstAddressForType(addresses1, RESIDENTIAL)
       const address3 = getFirstAddressForType(addresses1, SEARCH)
 
-      expect(address1).toEqual(pickupAdress)
+      expect(address1).toEqual(pickupAddress)
       expect(address2).toEqual(residentialAddress1)
-      expect(address3).toEqual(searchAdress)
+      expect(address3).toEqual(searchAddress)
     })
   })
 
@@ -275,11 +276,24 @@ describe('Address', () => {
       expect(addresses2).toEqual([])
     })
 
-    it('should add address', () => {
-      const pickupAdress = addresses.pickupPointAddress
-      const searchAdress = addresses.searchAddress
+    it('should add address on empty address list', () => {
       const residentialAddress1 = addresses.residentialAddress
-      const addresses1 = [pickupAdress, searchAdress]
+      const addresses1 = []
+      const expectedAddresses1 = [...addresses1, residentialAddress1]
+
+      const resultAddresses1 = addOrReplaceAddressOnList(
+        addresses1,
+        residentialAddress1
+      )
+
+      expect(resultAddresses1).toEqual(expectedAddresses1)
+    })
+
+    it('should add address', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const addresses1 = [pickupAddress, searchAddress]
       const expectedAddresses1 = [...addresses1, residentialAddress1]
 
       const resultAddresses1 = addOrReplaceAddressOnList(
@@ -291,14 +305,14 @@ describe('Address', () => {
     })
 
     it('should replace address with all info', () => {
-      const pickupAdress = addresses.pickupPointAddress
-      const searchAdress = addresses.searchAddress
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
       const residentialAddress1 = addresses.residentialAddress
       const residentialAddress2 = {
         ...addresses.residentialAddress,
         receiverName: 'Other Doe',
       }
-      const baseAddresses = [pickupAdress, searchAdress]
+      const baseAddresses = [pickupAddress, searchAddress]
       const addresses1 = [...baseAddresses, residentialAddress1]
       const expectedAddresses1 = [...baseAddresses, residentialAddress2]
 
@@ -308,6 +322,70 @@ describe('Address', () => {
       )
 
       expect(resultAddresses1).toEqual(expectedAddresses1)
+    })
+  })
+
+  describe('addPickupPointAddresses', () => {
+    it('should be empty if empty params are passed', () => {
+      const addresses1 = addPickupPointAddresses()
+      const addresses2 = addPickupPointAddresses([], null)
+
+      expect(addresses1).toBeUndefined()
+      expect(addresses2).toEqual([])
+    })
+
+    it('should add address but with search type on empty addresses', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const addresses1 = []
+      const pickupSlas = [
+        slas.pickupSla,
+      ]
+      const expectedAddresses = [
+        {
+          ...pickupAddress,
+          addressType: SEARCH,
+        },
+      ]
+
+      const newAddresses = addPickupPointAddresses(addresses1, pickupSlas)
+
+      expect(newAddresses).toEqual(expectedAddresses)
+    })
+
+    it('should add address but with search type on list of addresses', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const addresses1 = [residentialAddress1]
+      const pickupSlas = [
+        slas.pickupSla,
+      ]
+      const expectedAddresses = [
+        ...addresses1,
+        {
+          ...pickupAddress,
+          addressType: SEARCH,
+        },
+      ]
+
+      const newAddresses = addPickupPointAddresses(addresses1, pickupSlas)
+
+      expect(newAddresses).toEqual(expectedAddresses)
+    })
+
+    it('shouldnt add address if already on list of addresses', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const addresses1 = [pickupAddress, residentialAddress1]
+      const pickupSlas = [
+        slas.pickupSla,
+      ]
+      const expectedAddresses = [
+        ...addresses1,
+      ]
+
+      const newAddresses = addPickupPointAddresses(addresses1, pickupSlas)
+
+      expect(newAddresses).toEqual(expectedAddresses)
     })
   })
 })

--- a/tests/mockGenerator.js
+++ b/tests/mockGenerator.js
@@ -9,7 +9,22 @@ const addresses = {
     neighborhood: 'Copacabana',
     number: '5',
     postalCode: '22011050',
-    receiverName: 'auto auto',
+    receiverName: null,
+    reference: null,
+    state: 'RJ',
+    street: 'Rua General Azevedo Pimentel',
+  },
+  pickupPointAddress2: {
+    addressId: '141125e',
+    addressType: 'pickup',
+    city: 'Rio de Janeiro',
+    complement: '',
+    country: 'BRA',
+    geoCoordinates: [-43.18080139160156, -22.96540069580078],
+    neighborhood: 'Copacabana',
+    number: '5',
+    postalCode: '22011050',
+    receiverName: null,
     reference: null,
     state: 'RJ',
     street: 'Rua General Azevedo Pimentel',
@@ -150,10 +165,7 @@ const slas = {
     pickupStoreInfo: {
       isPickupStore: true,
       friendlyName: 'Shopping da Gávea',
-      address: {
-        ...addresses.pickupPointAddress,
-        receiverName: null,
-      },
+      address: addresses.pickupPointAddress,
     },
   },
   pickupNormalSla: {
@@ -170,10 +182,7 @@ const slas = {
     pickupStoreInfo: {
       isPickupStore: true,
       friendlyName: 'Shopping da Gávea',
-      address: {
-        ...addresses.pickupPointAddress,
-        receiverName: null,
-      },
+      address: addresses.pickupPointAddress2,
     },
   },
   expressSla: {

--- a/tests/mockGenerator.js
+++ b/tests/mockGenerator.js
@@ -196,6 +196,9 @@ const slas = {
     listPrice: 10000,
     sellingPrice: 10000,
     tax: 0,
+    pickupStoreInfo: {
+      isPickupStore: false,
+    },
   },
   normalSla: {
     id: 'Normal',
@@ -208,6 +211,9 @@ const slas = {
     listPrice: 5000,
     sellingPrice: 5000,
     tax: 0,
+    pickupStoreInfo: {
+      isPickupStore: false,
+    },
   },
   normalFastestSla: {
     id: 'Normal',
@@ -219,6 +225,9 @@ const slas = {
     listPrice: 20000,
     sellingPrice: 20000,
     tax: 0,
+    pickupStoreInfo: {
+      isPickupStore: false,
+    },
   },
   normalScheduledDeliverySla: {
     id: 'Agendada',
@@ -231,6 +240,9 @@ const slas = {
     listPrice: 5000,
     sellingPrice: 5000,
     tax: 0,
+    pickupStoreInfo: {
+      isPickupStore: false,
+    },
   },
   biggerWindowScheduledDeliverySla: {
     id: 'SuperAgendada',
@@ -243,6 +255,9 @@ const slas = {
     listPrice: 5000,
     sellingPrice: 5000,
     tax: 0,
+    pickupStoreInfo: {
+      isPickupStore: false,
+    },
   },
 }
 

--- a/tests/mockGenerator.js
+++ b/tests/mockGenerator.js
@@ -37,7 +37,7 @@ const addresses = {
     number: '2',
     complement: null,
     neighborhood: 'Botafogo',
-    postalCode: '22231-100',
+    postalCode: '22250-040',
     city: 'Rio de Janeiro',
     state: 'RJ',
     country: 'BRA',

--- a/tests/mockGenerator.js
+++ b/tests/mockGenerator.js
@@ -59,6 +59,21 @@ const addresses = {
     reference: null,
     geoCoordinates: [],
   },
+  residentialAddress2: {
+    addressId: '-4556418741088',
+    addressType: 'residential',
+    receiverName: 'John Doe',
+    street: 'Rua Barão',
+    number: '2',
+    complement: null,
+    neighborhood: 'Botafogo',
+    postalCode: '22231-100',
+    city: 'Rio de Janeiro',
+    state: 'RJ',
+    country: 'BRA',
+    reference: null,
+    geoCoordinates: [],
+  },
   giftRegistryAddress: {
     addressId: '-4556418741086',
     addressType: 'giftRegistry',
@@ -364,6 +379,23 @@ const createLogisticsInfo = (slaTypes, quantity, price = 0) => {
   }))
 }
 
+const createLogisticsInfoItem = ({
+  slas: slaTypes,
+  selectedSla: selectedSlaType,
+  price,
+  addressId,
+  index,
+}) => {
+  return {
+    ...createLogisticsInfo(slaTypes, 1, price)[0],
+    selectedSla: slas[selectedSlaType].id,
+    selectedDeliveryChannel: slas[selectedSlaType].deliveryChannel,
+    addressId,
+    itemIndex: index,
+    itemId: index,
+  }
+}
+
 module.exports = {
   addresses,
   slas,
@@ -372,4 +404,5 @@ module.exports = {
   createPackage,
   createItems,
   createLogisticsInfo,
+  createLogisticsInfoItem,
 }

--- a/tests/shipping.test.js
+++ b/tests/shipping.test.js
@@ -6,6 +6,7 @@ import {
   filterLogisticsInfo,
   getNewLogisticsInfoWithScheduledDeliveryChoice,
   replaceAddressIdOnLogisticsInfo,
+  getNewLogisticsMatchingSelectedAddresses,
 } from '../src/shipping'
 import { getDeliveredItems } from '../src/items'
 
@@ -1060,6 +1061,34 @@ describe('Shipping', () => {
       )
 
       expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
+  })
+
+  describe('getNewLogisticsMatchingSelectedAddresses', () => {
+    it('should return empty if empty params are passed', () => {
+      const {
+        logisticsInfo: logisticsInfo1,
+        selectedAddresses: selectedAddresses1,
+      } = getNewLogisticsMatchingSelectedAddresses()
+
+      const {
+        logisticsInfo: logisticsInfo2,
+        selectedAddresses: selectedAddresses2,
+      } = getNewLogisticsMatchingSelectedAddresses([])
+
+      const {
+        logisticsInfo: logisticsInfo3,
+        selectedAddresses: selectedAddresses3,
+      } = getNewLogisticsMatchingSelectedAddresses([], [])
+
+      expect(logisticsInfo1).toEqual([])
+      expect(selectedAddresses1).toBeUndefined()
+
+      expect(logisticsInfo2).toEqual([])
+      expect(selectedAddresses2).toBeUndefined()
+
+      expect(logisticsInfo3).toEqual([])
+      expect(selectedAddresses3).toEqual([])
     })
   })
 })

--- a/tests/shipping.test.js
+++ b/tests/shipping.test.js
@@ -5,12 +5,14 @@ import {
   getNewLogisticsInfoWithSelectedScheduled,
   filterLogisticsInfo,
   getNewLogisticsInfoWithScheduledDeliveryChoice,
+  replaceAddressIdOnLogisticsInfo,
 } from '../src/shipping'
 import { getDeliveredItems } from '../src/items'
 
 import {
   baseLogisticsInfo,
   createLogisticsInfo,
+  createLogisticsInfoItem,
   createItems,
   createPackage,
   slas,
@@ -263,11 +265,12 @@ describe('Shipping', () => {
 
     it('should return the pickup point address receiverName', () => {
       const items = createItems(1)
-      const packages = [
-        createPackage([{ itemIndex: 0, quantity: 1 }]),
-      ]
+      const packages = [createPackage([{ itemIndex: 0, quantity: 1 }])]
       const itemsWithIndex = items.map((item, index) => ({ ...item, index }))
-      const packagesWithIndex = packages.map((pack, index) => ({ ...pack, index }))
+      const packagesWithIndex = packages.map((pack, index) => ({
+        ...pack,
+        index,
+      }))
       const logisticsInfo = [
         {
           ...baseLogisticsInfo.pickup,
@@ -288,7 +291,9 @@ describe('Shipping', () => {
         selectedAddresses
       )
 
-      expect(result.address.receiverName).toBe(addresses.pickupPointAddress.receiverName)
+      expect(result.address.receiverName).toBe(
+        addresses.pickupPointAddress.receiverName
+      )
     })
   })
 
@@ -872,6 +877,186 @@ describe('Shipping', () => {
         logisticsInfo,
         scheduledDeliveryChoice,
         scheduledDeliveryItems
+      )
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
+  })
+
+  describe('replaceAddressIdOnLogisticsInfo', () => {
+    it('should return null if invalid params are passed', () => {
+      const newLogisticsInfo1 = replaceAddressIdOnLogisticsInfo()
+      const newLogisticsInfo2 = replaceAddressIdOnLogisticsInfo([])
+      const newLogisticsInfo3 = replaceAddressIdOnLogisticsInfo([], [])
+
+      expect(newLogisticsInfo1).toBeUndefined()
+      expect(newLogisticsInfo2).toEqual([])
+      expect(newLogisticsInfo3).toEqual([])
+    })
+
+    it('should return same logisticsInfo if all addressId are ok', () => {
+      const logisticsInfo = [
+        createLogisticsInfoItem({
+          slas: ['normalSla', 'normalScheduledDeliverySla'],
+          selectedSla: 'normalSla',
+          addressId: addresses.residentialAddress.addressId,
+          index: 0,
+        }),
+        createLogisticsInfoItem({
+          slas: ['normalSla', 'normalScheduledDeliverySla'],
+          selectedSla: 'normalScheduledDeliverySla',
+          addressId: addresses.residentialAddress.addressId,
+          index: 1,
+        }),
+      ]
+      const selectedAddresses = [addresses.residentialAddress]
+      const expectedLogisticsInfo = logisticsInfo
+
+      const newLogisticsInfo = replaceAddressIdOnLogisticsInfo(
+        logisticsInfo,
+        selectedAddresses
+      )
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
+
+    it('should return correct logisticsInfo if all addressId are invalid', () => {
+      const logisticsInfo = [
+        createLogisticsInfoItem({
+          slas: ['normalSla', 'normalScheduledDeliverySla'],
+          selectedSla: 'normalSla',
+          index: 0,
+        }),
+        createLogisticsInfoItem({
+          slas: ['normalSla', 'normalScheduledDeliverySla'],
+          selectedSla: 'normalScheduledDeliverySla',
+          index: 1,
+        }),
+      ]
+      const selectedAddresses = [addresses.residentialAddress]
+      const expectedLogisticsInfo = [
+        {
+          ...logisticsInfo[0],
+          addressId: addresses.residentialAddress.addressId,
+        },
+        {
+          ...logisticsInfo[1],
+          addressId: addresses.residentialAddress.addressId,
+        },
+      ]
+
+      const newLogisticsInfo = replaceAddressIdOnLogisticsInfo(
+        logisticsInfo,
+        selectedAddresses
+      )
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
+
+    it('should return correct logisticsInfo if one addressId are not present on selectedAddresses', () => {
+      const logisticsInfo = [
+        createLogisticsInfoItem({
+          slas: ['normalSla', 'normalScheduledDeliverySla'],
+          selectedSla: 'normalSla',
+          addressId: addresses.residentialAddress2.addressId,
+          index: 0,
+        }),
+        createLogisticsInfoItem({
+          slas: ['normalSla', 'normalScheduledDeliverySla'],
+          selectedSla: 'normalScheduledDeliverySla',
+          addressId: addresses.residentialAddress.addressId,
+          index: 1,
+        }),
+      ]
+      const selectedAddresses = [addresses.residentialAddress]
+      const expectedLogisticsInfo = [
+        {
+          ...logisticsInfo[0],
+          addressId: addresses.residentialAddress.addressId,
+        },
+        {
+          ...logisticsInfo[1],
+          addressId: addresses.residentialAddress.addressId,
+        },
+      ]
+
+      const newLogisticsInfo = replaceAddressIdOnLogisticsInfo(
+        logisticsInfo,
+        selectedAddresses
+      )
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
+
+    it('should return correct logisticsInfo if all addressId are not present on selectedAddresses', () => {
+      const logisticsInfo = [
+        createLogisticsInfoItem({
+          slas: ['normalSla', 'normalScheduledDeliverySla'],
+          selectedSla: 'normalSla',
+          addressId: addresses.residentialAddress2.addressId,
+          index: 0,
+        }),
+        createLogisticsInfoItem({
+          slas: ['normalSla', 'normalScheduledDeliverySla'],
+          selectedSla: 'normalScheduledDeliverySla',
+          addressId: addresses.residentialAddress2.addressId,
+          index: 1,
+        }),
+      ]
+      const selectedAddresses = [addresses.residentialAddress]
+      const expectedLogisticsInfo = [
+        {
+          ...logisticsInfo[0],
+          addressId: addresses.residentialAddress.addressId,
+        },
+        {
+          ...logisticsInfo[1],
+          addressId: addresses.residentialAddress.addressId,
+        },
+      ]
+
+      const newLogisticsInfo = replaceAddressIdOnLogisticsInfo(
+        logisticsInfo,
+        selectedAddresses
+      )
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
+
+    it('should return correct logisticsInfo if pickup slas are selected', () => {
+      const logisticsInfo = [
+        createLogisticsInfoItem({
+          slas: ['pickupSla', 'normalScheduledDeliverySla'],
+          selectedSla: 'pickupSla',
+          addressId: addresses.residentialAddress.addressId,
+          index: 0,
+        }),
+        createLogisticsInfoItem({
+          slas: ['normalSla', 'pickupNormalSla'],
+          selectedSla: 'pickupNormalSla',
+          addressId: addresses.residentialAddress.addressId,
+          index: 1,
+        }),
+      ]
+      const selectedAddresses = [
+        addresses.residentialAddress,
+        addresses.pickupPointAddress,
+        addresses.pickupPointAddress2,
+      ]
+      const expectedLogisticsInfo = [
+        {
+          ...logisticsInfo[0],
+          addressId: addresses.pickupPointAddress.addressId,
+        },
+        {
+          ...logisticsInfo[1],
+          addressId: addresses.pickupPointAddress2.addressId,
+        },
+      ]
+
+      const newLogisticsInfo = replaceAddressIdOnLogisticsInfo(
+        logisticsInfo,
+        selectedAddresses
       )
 
       expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)

--- a/tests/sla.test.js
+++ b/tests/sla.test.js
@@ -1,6 +1,7 @@
 import {
   getSelectedSla,
   getSelectedSlas,
+  getPickupSelectedSlas,
   getSlaObj,
   findSlaWithChannel,
   getSelectedSlaInSlas,
@@ -113,6 +114,51 @@ describe('Sla', () => {
       ]
 
       const selectedSlas = getSelectedSlas(logisticsInfo)
+
+      expect(selectedSlas).toEqual(expectedSlas)
+    })
+  })
+
+  describe('getPickupSelectedSlas', () => {
+    it('should return empty array if empty params are passed', () => {
+      const selectedSlas1 = getPickupSelectedSlas()
+      const selectedSlas2 = getPickupSelectedSlas([])
+
+      expect(selectedSlas1).toEqual([])
+      expect(selectedSlas2).toEqual([])
+    })
+
+    it('should return correct slas if logisticsInfo with selectedSlas are passed', () => {
+      const logisticsInfo = createLogisticsInfo(
+        ['normalSla', 'expressSla', 'pickupSla'],
+        3
+      )
+      logisticsInfo[0].selectedSla = slas.expressSla.id
+      logisticsInfo[1].selectedSla = slas.normalSla.id
+      logisticsInfo[2].selectedSla = slas.pickupSla.id
+
+      const expectedSlas = [
+        { ...slas.pickupSla, itemIndex: 2 },
+      ]
+
+      const selectedSlas = getPickupSelectedSlas(logisticsInfo)
+
+      expect(selectedSlas).toEqual(expectedSlas)
+    })
+
+    it('should return correct slas even if logisticsInfo dont have all selectedSlas', () => {
+      const logisticsInfo = createLogisticsInfo(
+        ['normalSla', 'expressSla', 'pickupSla'],
+        3
+      )
+      logisticsInfo[0].selectedSla = slas.expressSla.id
+      logisticsInfo[2].selectedSla = slas.pickupSla.id
+
+      const expectedSlas = [
+        { ...slas.pickupSla, itemIndex: 2 },
+      ]
+
+      const selectedSlas = getPickupSelectedSlas(logisticsInfo)
 
       expect(selectedSlas).toEqual(expectedSlas)
     })


### PR DESCRIPTION
Add getNewLogisticsMatchingSelectedAddresses, addOrReplaceAddressTypeOnList and its auxiliary functions

The goal of these new functions are allow checkout clients to dont worry about addressId matching and how to add new addresses to selectedAddresses
