### PR TITLE
Feature/merge logistics infos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1528,6 +1528,45 @@ Object on the format `{ items, packages }` containing the items and packages of 
 Type: `object`
 Object contained the keys delivered and toBeDelivered containing the right items and packages
 
+### getItemsIndexes (items)
+
+Return multiple values with information about the items indexes
+
+##### Usage
+```js
+const { getItemsIndexes } = require('@vtex/delivery-packages/dist/items')
+
+const items = [
+  { itemIndex: 0, sla: 'sla1' },
+  { itemIndex: 2, sla: 'sla2' },
+]
+
+getItemsIndexes(items)
+// -> {
+//   indexes: [0, 2],
+//   otherIndexes: [1],
+//   indexesMap: { 0: items[0], 2: items[1] },
+//   maxIndex: 2,
+// }
+```
+
+**params:**
+- **items**
+Type: `Array<object>`
+Array of items with itemIndex keys like the logisticsInfo of the orderForm
+
+**returns:**
+- **indexes context**
+Type: { indexes: `Array<number>`, otherIndexes: `Array<number>`, indexesMap: `object`, maxIndex: `number`}
+
+indexes: an array with all the numbers matching the items passed
+
+otherIndexes: an array with all the numbers not matching the items passed until maxIndex
+
+indexesMap: an object where the keys are the indexes and the values are the original items
+
+maxIndex: the maximum index found in the list of items
+
 ## Scheduled Delivery
 > @vtex/delivery-packages/dist/scheduled-delivery
 

--- a/README.md
+++ b/README.md
@@ -2587,6 +2587,62 @@ The selectedAddresses like the one inside `orderForm.shippingData` with address 
 Type: `{ logisticsInfo: Array<object>, selectedAddresses: Array<object> }`
 New logisticsInfo and selectedAddresses with matching addressIds and with all pickup addresses included
 
+### mergeLogisticsInfos (logisticsInfo1, logisticsInfo2)
+
+Get new logisticsInfo with the merged items from logisticsInfo1 and logisticsInfo2
+
+##### Usage
+```js
+const { mergeLogisticsInfos } = require('@vtex/delivery-packages/dist/shipping')
+
+const logisticsInfo1 = [
+  {
+    // You can pass all the properties of the logisticsInfo
+    "itemIndex": 0,
+    "selectedSla": "sla1",
+  },
+  {
+    // You can pass all the properties of the logisticsInfo
+    "itemIndex": 2,
+    "selectedSla": "sla3",
+  }
+]
+const logisticsInfo2 = [
+  {
+    // You can pass all the properties of the logisticsInfo
+    "itemIndex": 1,
+    "selectedSla": "sla2",
+  }
+]
+mergeLogisticsInfos(logisticsInfo1, logisticsInfo2)
+// -> [
+//   {
+//     "itemIndex": 0,
+//     "selectedSla": "sla1",
+//   },
+//   {
+//     "itemIndex": 1,
+//     "selectedSla": "sla2",
+//   },
+//   {
+//     "itemIndex": 2,
+//     "selectedSla": "sla3",
+//   },
+// ]
+```
+
+**params:**
+- **logisticsInfo1**
+Type: `Array<object>`
+The logisticsInfo like the one inside `orderForm.shippingData` with `itemIndex`
+- **logisticsInfo2**
+Type: `Array<object>`
+The logisticsInfo like the one inside `orderForm.shippingData` with `itemIndex`
+**returns:**
+- **new logisticsInfo**
+Type: `Array<object>`
+Return all items of logisticsInfo2 completing its missing items from the logisticsInfo1 (merge operation)
+
 ## SLA
 > @vtex/delivery-packages/dist/sla
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/delivery-packages",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/delivery-packages",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/delivery-packages",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/items.js
+++ b/src/items.js
@@ -1,5 +1,15 @@
 import './polyfills'
 
+/** PRIVATE **/
+
+function getItemIndex(item) {
+  if (!item) {
+    return -1
+  }
+  const index = item.index != null ? item.index : item.itemIndex
+  return index != null ? index : -1
+}
+
 /** PUBLIC **/
 
 export function getNewItems(items, changes) {
@@ -53,8 +63,8 @@ export function getDeliveredItems(params) {
     (groups, item) => {
       const packagesWithItem =
         packages &&
-        packages.filter(
-          pack => pack.items.some(packageItem => packageItem.itemIndex === item.index)
+        packages.filter(pack =>
+          pack.items.some(packageItem => packageItem.itemIndex === item.index)
         )
 
       if (packagesWithItem.length === 0) {
@@ -100,4 +110,42 @@ export function getDeliveredItems(params) {
   )
 
   return deliveredItems
+}
+
+export function getItemsIndexes(items) {
+  if (!items || items.length === 0) {
+    return {
+      indexes: [],
+      otherIndexes: [],
+      indexesMap: {},
+      maxIndex: -1,
+    }
+  }
+
+  const indexesMap = {}
+  const indexes = []
+  const otherIndexes = []
+  let maxIndex = 0
+
+  items.forEach(item => {
+    const itemIndex = getItemIndex(item)
+    maxIndex = Math.max(maxIndex, itemIndex)
+    if (itemIndex !== -1) {
+      indexesMap[itemIndex] = item
+      indexes.push(itemIndex)
+    }
+  })
+
+  for (let index = 0; index < maxIndex; index++) {
+    if (!indexesMap[index]) {
+      otherIndexes.push(index)
+    }
+  }
+
+  return {
+    indexes,
+    otherIndexes,
+    indexesMap,
+    maxIndex,
+  }
 }

--- a/src/items.js
+++ b/src/items.js
@@ -2,7 +2,7 @@ import './polyfills'
 
 /** PRIVATE **/
 
-function getItemIndex(item) {
+export function getItemIndex(item) {
   if (!item) {
     return -1
   }

--- a/src/items.js
+++ b/src/items.js
@@ -112,7 +112,7 @@ export function getDeliveredItems(params) {
   return deliveredItems
 }
 
-export function getItemsIndexes(items) {
+export function getItemsIndexes(items, len = -1) {
   if (!items || items.length === 0) {
     return {
       indexes: [],
@@ -136,7 +136,9 @@ export function getItemsIndexes(items) {
     }
   })
 
-  for (let index = 0; index < maxIndex; index++) {
+  len = Math.max(len, maxIndex)
+
+  for (let index = 0; index < len; index++) {
     if (!indexesMap[index]) {
       otherIndexes.push(index)
     }

--- a/src/shipping.js
+++ b/src/shipping.js
@@ -5,7 +5,7 @@ import {
   getFirstAddressForDelivery,
 } from './address'
 import { isPickup, isDelivery, getDeliveryChannel } from './delivery-channel'
-import { getItemIndex, getItemsIndexes } from './items'
+import { getItemsIndexes } from './items'
 import {
   hasDeliveryWindows,
   getSelectedSla,
@@ -305,18 +305,16 @@ export function mergeLogisticsInfos(logisticsInfo1, logisticsInfo2) {
   logisticsInfo1 = fillGapsInLogisticsInfo(logisticsInfo1, false)
   logisticsInfo2 = fillGapsInLogisticsInfo(logisticsInfo2, false)
 
-  return logisticsInfo1.reduce((newLogisticsInfo, li, index) => {
-    let itemIndex = getItemIndex(li)
-    if (itemIndex === -1) {
-      itemIndex = index
-    }
+  const maxLen = Math.max(logisticsInfo1.length, logisticsInfo2.length)
 
-    if (itemIndex >= 0 && logisticsInfo2[itemIndex]) {
-      return [...newLogisticsInfo, logisticsInfo2[itemIndex]]
-    }
+  const newLogisticsInfo = []
 
-    return [...newLogisticsInfo, li]
-  }, [])
+  for (let itemIndex = 0; itemIndex < maxLen; itemIndex++) {
+    const newItem = logisticsInfo2[itemIndex] || logisticsInfo1[itemIndex]
+    newLogisticsInfo.push(newItem)
+  }
+
+  return newLogisticsInfo
 }
 
 export function getNewLogisticsInfoWithScheduledDeliveryChoice(

--- a/src/shipping.js
+++ b/src/shipping.js
@@ -5,6 +5,7 @@ import {
   getFirstAddressForDelivery,
 } from './address'
 import { isPickup, isDelivery, getDeliveryChannel } from './delivery-channel'
+import { getItemIndex, getItemsIndexes } from './items'
 import {
   hasDeliveryWindows,
   getSelectedSla,
@@ -142,6 +143,30 @@ export function replaceAddressIdOnLogisticsInfo(
   })
 }
 
+export function fillGapsInLogisticsInfo(logisticsInfo, fillWithIndex = true) {
+  if (!logisticsInfo || logisticsInfo.length === 0) {
+    return []
+  }
+
+  const { maxIndex, indexesMap } = getItemsIndexes(logisticsInfo)
+
+  const newLogisticsInfo = []
+
+  for (let index = 0; index <= maxIndex; index++) {
+    if (indexesMap[index]) {
+      newLogisticsInfo.push(indexesMap[index])
+    } else {
+      if (fillWithIndex) {
+        newLogisticsInfo.push({ itemIndex: index })
+      } else {
+        newLogisticsInfo.push(null)
+      }
+    }
+  }
+
+  return newLogisticsInfo
+}
+
 /** PUBLIC **/
 
 export function getNewLogisticsInfo(
@@ -266,6 +291,32 @@ export function filterLogisticsInfo(logisticsInfo, filters, keepSize = false) {
       )
       : logisticsInfo.filter(li => indexes.indexOf(li.itemIndex) !== -1)
     : logisticsInfo
+}
+
+export function mergeLogisticsInfos(logisticsInfo1, logisticsInfo2) {
+  if (!logisticsInfo1 || logisticsInfo1.length === 0) {
+    return []
+  }
+
+  if (!logisticsInfo2 || logisticsInfo2.length === 0) {
+    return logisticsInfo1
+  }
+
+  logisticsInfo1 = fillGapsInLogisticsInfo(logisticsInfo1, false)
+  logisticsInfo2 = fillGapsInLogisticsInfo(logisticsInfo2, false)
+
+  return logisticsInfo1.reduce((newLogisticsInfo, li, index) => {
+    let itemIndex = getItemIndex(li)
+    if (itemIndex === -1) {
+      itemIndex = index
+    }
+
+    if (itemIndex >= 0 && logisticsInfo2[itemIndex]) {
+      return [...newLogisticsInfo, logisticsInfo2[itemIndex]]
+    }
+
+    return [...newLogisticsInfo, li]
+  }, [])
 }
 
 export function getNewLogisticsInfoWithScheduledDeliveryChoice(

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -1,4 +1,4 @@
-import { getNewItems, getDeliveredItems } from '../src/items'
+import { getNewItems, getDeliveredItems, getItemsIndexes } from '../src/items'
 
 import { createItems, createPackage } from './mockGenerator'
 
@@ -218,11 +218,11 @@ describe('Items', () => {
 
   it('should get the right item index', () => {
     const items = [
-      { 'id': '0', 'quantity': 1, 'seller': '1', 'index': 0 },
-      { 'id': '3', 'quantity': 1, 'seller': '1', 'index': 3 },
-      { 'id': '4', 'quantity': 1, 'seller': '1', 'index': 4 },
-      { 'id': '5', 'quantity': 1, 'seller': '1', 'index': 5 },
-      { 'id': '6', 'quantity': 1, 'seller': '1', 'index': 6 },
+      { id: '0', quantity: 1, seller: '1', index: 0 },
+      { id: '3', quantity: 1, seller: '1', index: 3 },
+      { id: '4', quantity: 1, seller: '1', index: 4 },
+      { id: '5', quantity: 1, seller: '1', index: 5 },
+      { id: '6', quantity: 1, seller: '1', index: 6 },
     ]
     const packages = [
       createPackage([
@@ -238,5 +238,51 @@ describe('Items', () => {
 
     expect(deliveredItems.toBeDelivered).toHaveLength(0)
     expect(deliveredItems.delivered).toHaveLength(5)
+  })
+
+  describe('getItemsIndexes', () => {
+    it('should return empty values if empty logisticsInfo is passed', () => {
+      const { indexes, otherIndexes, indexesMap, maxIndex } = getItemsIndexes(
+        []
+      )
+
+      expect(indexes).toEqual([])
+      expect(otherIndexes).toEqual([])
+      expect(indexesMap).toEqual({})
+      expect(maxIndex).toEqual(-1)
+    })
+
+    it('should return indexes values and map with incomplete items list', () => {
+      const items = [
+        { itemIndex: 0, sla: 'sla1' },
+        { itemIndex: 2, sla: 'sla2' },
+      ]
+
+      const { indexes, otherIndexes, indexesMap, maxIndex } = getItemsIndexes(
+        items
+      )
+
+      expect(indexes).toEqual([0, 2])
+      expect(otherIndexes).toEqual([1])
+      expect(indexesMap).toEqual({ 0: items[0], 2: items[1] })
+      expect(maxIndex).toEqual(2)
+    })
+
+    it('should return indexes values and map with complete items list', () => {
+      const items = [
+        { itemIndex: 0, sla: 'sla1' },
+        { itemIndex: 1, sla: 'sla2' },
+        { itemIndex: 2, sla: 'sla3' },
+      ]
+
+      const { indexes, otherIndexes, indexesMap, maxIndex } = getItemsIndexes(
+        items
+      )
+
+      expect(indexes).toEqual([0, 1, 2])
+      expect(otherIndexes).toEqual([])
+      expect(indexesMap).toEqual({ 0: items[0], 1: items[1], 2: items[2] })
+      expect(maxIndex).toEqual(2)
+    })
   })
 })

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -284,5 +284,21 @@ describe('Items', () => {
       expect(indexesMap).toEqual({ 0: items[0], 1: items[1], 2: items[2] })
       expect(maxIndex).toEqual(2)
     })
+
+    it('should return indexes values and map with more lenght on list', () => {
+      const items = [
+        { itemIndex: 1, sla: 'sla2' },
+      ]
+      const totalItems = 3
+
+      const { indexes, otherIndexes, indexesMap, maxIndex } = getItemsIndexes(
+        items, totalItems
+      )
+
+      expect(indexes).toEqual([1])
+      expect(otherIndexes).toEqual([0, 2])
+      expect(indexesMap).toEqual({ 1: items[0] })
+      expect(maxIndex).toEqual(1)
+    })
   })
 })

--- a/tests/shipping.test.js
+++ b/tests/shipping.test.js
@@ -1408,5 +1408,39 @@ describe('Shipping', () => {
 
       expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
     })
+
+    it('should return merged logisticsInfo if logisticsInfo1 is different than logisticsInfo2 and logisticsInfo2 have items with more index', () => {
+      const logisticsInfo1 = [
+        createLogisticsInfoItem({
+          slas: ['pickupSla', 'expressSla'],
+          selectedSla: 'expressSla',
+          index: 0,
+        }),
+        createLogisticsInfoItem({
+          slas: ['pickupSla', 'expressSla'],
+          selectedSla: 'expressSla',
+          index: 1,
+        }),
+      ]
+      const logisticsInfo2 = [
+        createLogisticsInfoItem({
+          slas: ['pickupSla', 'normalScheduledDeliverySla'],
+          selectedSla: 'pickupSla',
+          index: 2,
+        }),
+      ]
+      const expectedLogisticsInfo = [
+        logisticsInfo1[0],
+        logisticsInfo1[1],
+        logisticsInfo2[0],
+      ]
+
+      const newLogisticsInfo = mergeLogisticsInfos(
+        logisticsInfo1,
+        logisticsInfo2
+      )
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
   })
 })

--- a/tests/shipping.test.js
+++ b/tests/shipping.test.js
@@ -7,6 +7,8 @@ import {
   getNewLogisticsInfoWithScheduledDeliveryChoice,
   replaceAddressIdOnLogisticsInfo,
   getNewLogisticsMatchingSelectedAddresses,
+  fillGapsInLogisticsInfo,
+  mergeLogisticsInfos,
 } from '../src/shipping'
 import { SEARCH } from '../src/constants'
 import { getDeliveredItems } from '../src/items'
@@ -1248,6 +1250,163 @@ describe('Shipping', () => {
 
       expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
       expect(newSelectedAddresses).toEqual(expectedSelectedAddresses)
+    })
+  })
+
+  describe('fillGapsInLogisticsInfo', () => {
+    it('should return empty array when passing empty array', () => {
+      expect(fillGapsInLogisticsInfo([])).toEqual([])
+    })
+
+    it('should return same logisticsInfo with no gaps', () => {
+      const logisticsInfo = createLogisticsInfo(['pickupSla', 'expressSla'], 3)
+      const expectedLogisticsInfo = logisticsInfo
+
+      const newLogisticsInfo = fillGapsInLogisticsInfo(logisticsInfo)
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
+
+    it('should complete the gaps of logisticsInfo', () => {
+      const logisticsInfo = createLogisticsInfo(['pickupSla', 'expressSla'], 3)
+      logisticsInfo[1] = null
+      const expectedLogisticsInfo = [
+        logisticsInfo[0],
+        { itemIndex: 1 },
+        logisticsInfo[2],
+      ]
+
+      const newLogisticsInfo = fillGapsInLogisticsInfo(logisticsInfo)
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
+    it('should complete the gaps of logisticsInfo with null values if fillWithIndex is passed as false', () => {
+      const logisticsInfo = createLogisticsInfo(['pickupSla', 'expressSla'], 3)
+      logisticsInfo[1] = null
+      const fillWithIndex = false
+      const expectedLogisticsInfo = [logisticsInfo[0], null, logisticsInfo[2]]
+
+      const newLogisticsInfo = fillGapsInLogisticsInfo(
+        logisticsInfo,
+        fillWithIndex
+      )
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
+  })
+
+  describe('mergeLogisticsInfos', () => {
+    it('should return empty array when passing empty array', () => {
+      expect(mergeLogisticsInfos()).toEqual([])
+      expect(mergeLogisticsInfos([])).toEqual([])
+      expect(mergeLogisticsInfos([], [])).toEqual([])
+    })
+
+    it('should return same logisticsInfo if empty logisticsInfo2 is passed', () => {
+      const logisticsInfo1 = createLogisticsInfo(['pickupSla', 'expressSla'], 3)
+      const expectedLogisticsInfo = logisticsInfo1
+
+      const newLogisticsInfo = mergeLogisticsInfos(logisticsInfo1, [])
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
+
+    it('should return logisticsInfo2 if logisticsInfo1 is different than logisticsInfo2 and have the same size', () => {
+      const logisticsInfo1 = createLogisticsInfo(['pickupSla', 'expressSla'], 3)
+      const logisticsInfo2 = createLogisticsInfo(
+        ['pickupSla', 'normalScheduledDeliverySla'],
+        3
+      )
+      const expectedLogisticsInfo = logisticsInfo2
+
+      const newLogisticsInfo = mergeLogisticsInfos(
+        logisticsInfo1,
+        logisticsInfo2
+      )
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
+
+    it('should return merged logisticsInfo if logisticsInfo1 is different than logisticsInfo2 and dont the same indexes', () => {
+      const logisticsInfo1 = createLogisticsInfo(['pickupSla', 'expressSla'], 3)
+      const logisticsInfo2 = [
+        createLogisticsInfoItem({
+          slas: ['pickupSla', 'normalScheduledDeliverySla'],
+          selectedSla: 'pickupSla',
+          index: 1,
+        }),
+      ]
+      const expectedLogisticsInfo = [
+        logisticsInfo1[0],
+        logisticsInfo2[0],
+        logisticsInfo1[2],
+      ]
+
+      const newLogisticsInfo = mergeLogisticsInfos(
+        logisticsInfo1,
+        logisticsInfo2
+      )
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
+
+    it('should return merged logisticsInfo if logisticsInfo1 is different than logisticsInfo2, dont the same indexes and both have null gaps', () => {
+      const logisticsInfo1 = createLogisticsInfo(['pickupSla', 'expressSla'], 3)
+      logisticsInfo1[1] = null
+      const logisticsInfo2 = [
+        null,
+        createLogisticsInfoItem({
+          slas: ['pickupSla', 'normalScheduledDeliverySla'],
+          selectedSla: 'pickupSla',
+          index: 1,
+        }),
+      ]
+      const expectedLogisticsInfo = [
+        logisticsInfo1[0],
+        logisticsInfo2[1],
+        logisticsInfo1[2],
+      ]
+
+      const newLogisticsInfo = mergeLogisticsInfos(
+        logisticsInfo1,
+        logisticsInfo2
+      )
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
+    })
+
+    it('should return merged logisticsInfo if logisticsInfo1 is different than logisticsInfo2, dont the same indexes and both have gaps', () => {
+      const logisticsInfo1 = [
+        createLogisticsInfoItem({
+          slas: ['pickupSla', 'expressSla'],
+          selectedSla: 'expressSla',
+          index: 0,
+        }),
+        createLogisticsInfoItem({
+          slas: ['pickupSla', 'expressSla'],
+          selectedSla: 'expressSla',
+          index: 2,
+        }),
+      ]
+      const logisticsInfo2 = [
+        createLogisticsInfoItem({
+          slas: ['pickupSla', 'normalScheduledDeliverySla'],
+          selectedSla: 'pickupSla',
+          index: 1,
+        }),
+      ]
+      const expectedLogisticsInfo = [
+        logisticsInfo1[0],
+        logisticsInfo2[0],
+        logisticsInfo1[1],
+      ]
+
+      const newLogisticsInfo = mergeLogisticsInfos(
+        logisticsInfo1,
+        logisticsInfo2
+      )
+
+      expect(newLogisticsInfo).toEqual(expectedLogisticsInfo)
     })
   })
 })


### PR DESCRIPTION
Create the getItemsIndexes  and mergeLogisticsInfos functions that allow you to filter, reorder and merge the logisticsInfo items better.

On inStore we will use these functions so that the logic for picking the cheapest and fastests skip the pickup items