### PR TITLE
Use `marketplaceItems` instead of `items` if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.17.0] - 2019-01-21
+
 ### Added
 
 - Creates the parcel object using the `marketplaceItems` instead of the `items` if `marketplaceItems` has something in it and if the criteria `useMarketplaceItems` is true.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Creates the parcel object using the `marketplaceItems` instead of the `items` if `marketplaceItems` has something in it and if the criteria `useMarketplaceItems` is true.
+- Change the default options of `parcelify` adding `useMarketplaceItems` as `true`.
+
 ## [2.16.2] - 2018-12-12
 
 ## Fixed
+
 - `addressType` is now case insensitive on address functions
 
 ## [2.16.1] - 2018-12-07
@@ -17,9 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.16.0] - 2018-12-07
 
 ## Fixed
+
 - `getSlaType` for old checkIn
 
 ## Added
+
 - CheckIn and utils functions (still without docs until we believe they should be public)
 
 ## [2.15.0] - 2018-11-27

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Default:<br/>
   selectedSla: true,
   seller: true,
   shippingEstimate: true,
-  deliveryChannel: true
+  deliveryChannel: true,
+  useMarketplaceItems: true
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/delivery-packages",
-  "version": "2.16.2",
+  "version": "2.17.0",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,7 @@ export const DEFAULT_CRITERIA = {
   seller: true,
   shippingEstimate: true,
   deliveryChannel: true,
+  useMarketplaceItems: true,
 }
 
 export const PICKUP_IN_STORE = 'pickup-in-point'

--- a/src/parcel.js
+++ b/src/parcel.js
@@ -208,6 +208,7 @@ function addToPackage(items, criteria, order, fn) {
 export function parcelify(order, options = {}) {
   const {
     items = [],
+    marketplaceItems = [],
     packageAttachment = {},
     shippingData = {},
     changesAttachment = {},
@@ -231,7 +232,17 @@ export function parcelify(order, options = {}) {
     ? changesAttachment.changesData
     : []
 
-  const itemsWithIndex = items.map((item, index) => ({ ...item, index }))
+  const FIXED_ITEM_INDEX = 0
+  const useItems = criteria.useMarketplaceItems === false ||
+    marketplaceItems.length === 0
+
+  const itemsWithIndex = useItems
+    ? items.map((item, index) => ({ ...item, index }))
+    : marketplaceItems.map(item => ({
+      ...item,
+      index: FIXED_ITEM_INDEX,
+    }))
+
   const packagesWithIndex = packages.map((pack, index) => ({ ...pack, index }))
 
   const itemsCleaned = getNewItems(itemsWithIndex, changes)

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -11,6 +11,7 @@ import {
   createLogisticsInfo,
 } from './mockGenerator'
 import orderMock from './Order'
+import { DEFAULT_CRITERIA } from '../src/constants'
 
 const {
   expressSla,
@@ -1865,5 +1866,51 @@ describe('Order with changes and all delivered', () => {
     })
 
     expect(result).toHaveLength(1)
+  })
+})
+
+describe('Order with marketplaceItems (gift list)', () => {
+  it('should create packages successfully', () => {
+    const items = createItems(1)
+    const marketplaceItems = createItems(2)
+    const selectedAddresses = [residentialAddress]
+    const logisticInfo = { ...baseLogisticsInfo.normal, slas: null }
+    const logisticsInfo = [
+      { ...logisticInfo, itemIndex: 0 },
+    ]
+
+    const result = parcelify({
+      items,
+      marketplaceItems,
+      shippingData: {
+        logisticsInfo,
+        selectedAddresses,
+      },
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].items).toHaveLength(2)
+  })
+
+  it('should not consider marketplaceItems if criteria is false', () => {
+    const items = createItems(1)
+    const marketplaceItems = createItems(2)
+    const selectedAddresses = [residentialAddress]
+    const logisticInfo = { ...baseLogisticsInfo.normal, slas: null }
+    const logisticsInfo = [
+      { ...logisticInfo, itemIndex: 0 },
+    ]
+
+    const result = parcelify({
+      items,
+      marketplaceItems,
+      shippingData: {
+        logisticsInfo,
+        selectedAddresses,
+      },
+    }, { criteria: { useMarketplaceItems: false } })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].items).toHaveLength(1)
   })
 })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Handle scenarios which the order has `marketplaceItems`.

#### What problem is this solving?

1. The user Felipe created a wedding list, registered the items and set it to generate the value of the order in gift cards.
2. The user Pedro bought two items of the wedding list of Felipe, a microwave and a towel. The total of the order is 200 dollars.
3. When finishing the order, the API change the items of the order to just one item called "Gera Vale" with the same value of the order. It also stores the original items, the microwave and the towel, inside the property `marketplaceItems` of the order.
4. Today, in the OMS, we display "Gera Vale" and in another session, the items that were originally bought, the microwave and the towel.
5. In My Orders, we should display to the user Pedro, the items inside `marketplaceItems`, instead of the items in `items`.

This commit solves this.

It creates the parcel object using the `marketplaceItems` instead of the `items` if `marketplaceItems` has something in it and if the criteria `useMarketplaceItems` is true.

#### How should this be manually tested?

Check new unit tests.

#### Screenshots or example usage
n/a

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)