### PR TITLE
Make the number validation optional for complete address verification 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Options to number verification at `isAddressComplete` function
 
 ## [2.17.1] - 2019-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.17.2] - 2020-03-18
 ### Added
 - Options to number verification at `isAddressComplete` function
 

--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ Type: `object`
 An object containing all address fields like on availableAddresses of orderForm
 
 - **requiredFields**
-Type: `object`
+Type: `array`
 An array containing all required fields. The default required address fields are `state`, `city`, `neighborhood`, `street` and `number`.
 
 **returns:**

--- a/README.md
+++ b/README.md
@@ -704,12 +704,38 @@ isAddressComplete({
   geoCoordinates: [],
 })
 // -> false
+
+isAddressComplete({
+  addressId: '-4556418741084',
+  addressType: 'residential',
+  receiverName: 'John Doe',
+  street: 'Rua Barão',
+  number: null,
+  complement: null,
+  neighborhood: 'Botafogo',
+  postalCode: '22231-100',
+  city: 'Rio de Janeiro',
+  state: 'RJ',
+  country: 'BRA',
+  reference: null,
+  geoCoordinates: [],
+}, [
+  'state',
+  'city',
+  'neighborhood',
+  'street',
+])
+// -> true
 ```
 
 **params:**
 - **address**
 Type: `object`
 An object containing all address fields like on availableAddresses of orderForm
+
+- **requiredFields**
+Type: `object`
+An array containing all required fields. The default required address fields are `state`, `city`, `neighborhood`, `street` and `number`.
 
 **returns:**
 - **isAddressComplete**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/delivery-packages",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/address.js
+++ b/src/address.js
@@ -6,7 +6,6 @@ import {
   GIFT_REGISTRY,
 } from './constants'
 import uuid from './uuid'
-import get from 'lodash/get'
 
 /** PRIVATE **/
 
@@ -65,17 +64,19 @@ export function isCurrentAddressType(address, addressType) {
 
 /** PUBLIC **/
 
-export function isAddressComplete(address, options) {
-  const { number, street, neighborhood, city, state } = address || {}
-  const verifyNumber = !(get(options, 'verifyNumber') === false)
+export const defaultRequiredAddressFields = [
+  'state',
+  'city',
+  'neighborhood',
+  'street',
+  'number',
+]
 
-  return !!(
-    (!verifyNumber || number) &&
-    street &&
-    neighborhood &&
-    city &&
-    state
-  )
+export function isAddressComplete(
+  address,
+  requiredFields = defaultRequiredAddressFields
+) {
+  return !!address && requiredFields.every(field => !!address[field])
 }
 
 export function isGiftRegistry(address) {
@@ -130,13 +131,13 @@ export function findAddressByPostalCode(addresses, searchAddress) {
   return findAddress(addresses, searchAddress, 'postalCode')
 }
 
-export function getDeliveryAvailableAddresses(addresses, options) {
+export function getDeliveryAvailableAddresses(addresses, requiredFields) {
   if (!addresses || addresses.length === 0) {
     return []
   }
 
   return addresses.filter(address => {
-    return isAddressComplete(address, options) && isDeliveryAddress(address)
+    return isAddressComplete(address, requiredFields) && isDeliveryAddress(address)
   })
 }
 

--- a/src/address.js
+++ b/src/address.js
@@ -6,6 +6,7 @@ import {
   GIFT_REGISTRY,
 } from './constants'
 import uuid from './uuid'
+import get from 'lodash/get'
 
 /** PRIVATE **/
 
@@ -64,9 +65,17 @@ export function isCurrentAddressType(address, addressType) {
 
 /** PUBLIC **/
 
-export function isAddressComplete(address) {
+export function isAddressComplete(address, options) {
   const { number, street, neighborhood, city, state } = address || {}
-  return !!(number && street && neighborhood && city && state)
+  const verifyNumber = !(get(options, 'verifyNumber') === false)
+
+  return !!(
+    (!verifyNumber || number) &&
+    street &&
+    neighborhood &&
+    city &&
+    state
+  )
 }
 
 export function isGiftRegistry(address) {
@@ -121,13 +130,13 @@ export function findAddressByPostalCode(addresses, searchAddress) {
   return findAddress(addresses, searchAddress, 'postalCode')
 }
 
-export function getDeliveryAvailableAddresses(addresses) {
+export function getDeliveryAvailableAddresses(addresses, options) {
   if (!addresses || addresses.length === 0) {
     return []
   }
 
   return addresses.filter(address => {
-    return isAddressComplete(address) && isDeliveryAddress(address)
+    return isAddressComplete(address, options) && isDeliveryAddress(address)
   })
 }
 

--- a/tests/address.test.js
+++ b/tests/address.test.js
@@ -54,14 +54,14 @@ describe('Address', () => {
       expect(isAddressComplete1).toBeTruthy()
     })
 
-    it('should be false if missing number when it is explicity required', () => {
+    it('should be false if missing number when it is explicitly required', () => {
       const completeAddress = { ...addresses.residentialAddress, number: null }
       const isAddressComplete1 = isAddressComplete(completeAddress, { verifyNumber: true })
 
       expect(isAddressComplete1).toBeFalsy()
     })
 
-    it('should be false if missing number when it is implicit required', () => {
+    it('should be false if missing number when it is implicitly required', () => {
       const completeAddress = { ...addresses.residentialAddress, number: null }
       const isAddressComplete1 = isAddressComplete(completeAddress)
 

--- a/tests/address.test.js
+++ b/tests/address.test.js
@@ -49,14 +49,27 @@ describe('Address', () => {
 
     it('should be true if missing number when it is not required', () => {
       const completeAddress = { ...addresses.residentialAddress, number: null }
-      const isAddressComplete1 = isAddressComplete(completeAddress, { verifyNumber: false })
+      const requiredFields = [
+        'state',
+        'city',
+        'neighborhood',
+        'street',
+      ]
+      const isAddressComplete1 = isAddressComplete(completeAddress, requiredFields)
 
       expect(isAddressComplete1).toBeTruthy()
     })
 
     it('should be false if missing number when it is explicitly required', () => {
       const completeAddress = { ...addresses.residentialAddress, number: null }
-      const isAddressComplete1 = isAddressComplete(completeAddress, { verifyNumber: true })
+      const requiredFields = [
+        'state',
+        'city',
+        'neighborhood',
+        'street',
+        'number',
+      ]
+      const isAddressComplete1 = isAddressComplete(completeAddress, requiredFields)
 
       expect(isAddressComplete1).toBeFalsy()
     })
@@ -235,12 +248,18 @@ describe('Address', () => {
         ...addresses.residentialAddress,
         number: null,
       }
+      const requiredFields = [
+        'state',
+        'city',
+        'neighborhood',
+        'street',
+      ]
 
       const addresses1 = getDeliveryAvailableAddresses([
         incompleteAddress1,
         residentialAddress1,
         withoutNumberAddress,
-      ], { verifyNumber: false })
+      ], requiredFields)
 
       expect(addresses1).toEqual([residentialAddress1, withoutNumberAddress])
     })

--- a/tests/address.test.js
+++ b/tests/address.test.js
@@ -46,6 +46,27 @@ describe('Address', () => {
 
       expect(isAddressComplete1).toBeTruthy()
     })
+
+    it('should be true if missing number when it is not required', () => {
+      const completeAddress = { ...addresses.residentialAddress, number: null }
+      const isAddressComplete1 = isAddressComplete(completeAddress, { verifyNumber: false })
+
+      expect(isAddressComplete1).toBeTruthy()
+    })
+
+    it('should be false if missing number when it is explicity required', () => {
+      const completeAddress = { ...addresses.residentialAddress, number: null }
+      const isAddressComplete1 = isAddressComplete(completeAddress, { verifyNumber: true })
+
+      expect(isAddressComplete1).toBeFalsy()
+    })
+
+    it('should be false if missing number when it is implicit required', () => {
+      const completeAddress = { ...addresses.residentialAddress, number: null }
+      const isAddressComplete1 = isAddressComplete(completeAddress)
+
+      expect(isAddressComplete1).toBeFalsy()
+    })
   })
 
   describe('isPickupAddress', () => {
@@ -202,6 +223,26 @@ describe('Address', () => {
       ])
 
       expect(addresses1).toEqual([residentialAddress1, residentialAddress2])
+    })
+
+    it('should maintain without number addresses if it is not required', () => {
+      const incompleteAddress1 = {
+        ...addresses.residentialAddress,
+        street: null,
+      }
+      const residentialAddress1 = addresses.residentialAddress
+      const withoutNumberAddress = {
+        ...addresses.residentialAddress,
+        number: null,
+      }
+
+      const addresses1 = getDeliveryAvailableAddresses([
+        incompleteAddress1,
+        residentialAddress1,
+        withoutNumberAddress,
+      ], { verifyNumber: false })
+
+      expect(addresses1).toEqual([residentialAddress1, withoutNumberAddress])
     })
   })
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make the number validation optional for complete address verification 
#### What problem is this solving?
The inStore considers a without number address as a complete address.
#### How should this be manually tested?
`jest`
#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
