### PR TITLE
Add setDeliveryAddressOnList on address functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add new address function named `addOrReplaceDeliveryAddressOnList`
 
 ## [2.17.2] - 2020-03-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.18.0] - 2020-04-15
 ### Added
 - Add new address function named `setDeliveryAddressOnList`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Add new address function named `addOrReplaceDeliveryAddressOnList`
+- Add new address function named `setDeliveryAddressOnList`
 
 ## [2.17.2] - 2020-03-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -1547,12 +1547,12 @@ addOrReplaceDeliveryAddressOnList([
 Type: `Array<object>`
 An array which each item is an object containing all address fields like on selectedAddresses of orderForm
 - **newAddress**
-Type: `string`
+Type: `object`
 New address to be included on the list of addresses
 
 **returns:**
 - **new addresses**
-Type: `object`
+Type: `Array<object>`
 New list of addresses with the newAddress included
 
 ## Delivery Channel

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ npm install @vtex/delivery-packages
 - [groupByAddressType](#groupbyaddresstype-addresses)
 - [addOrReplaceAddressTypeOnList](#addorreplaceaddresstypeonlist-addresses-newaddress)
 - [addOrReplaceAddressOnList](#addorreplaceaddressonlist-addresses-newaddress)
-- [addOrReplaceDeliveryAddressOnList](#addorreplacedeliveryaddressonlist-addresses-newaddress)
+- [setDeliveryAddressOnList](#setdeliveryaddressonlist-addresses-newaddress)
 
 #### Delivery Channel
 
@@ -1388,15 +1388,15 @@ New address to be included on the list of addresses
 Type: `object`
 New list of addresses with the newAddress included
 
-## addOrReplaceDeliveryAddressOnList (addresses, newAddress)
+## setDeliveryAddressOnList (addresses, newAddress)
 
-Adds new address if no delivery address exists on addresses and if addressType of newAddress is delivery or replace an existing address of the delivery type
+Adds a new address if no delivery address exists on addresses and the `addressType` of `newAddress` is delivery **or** replace an existing delivery address with the current delivery address merged with the `newAddress` data.
 
 ##### Usage
 ```js
-const { addOrReplaceDeliveryAddressOnList } = require('@vtex/delivery-packages/dist/address')
+const { setDeliveryAddressOnList } = require('@vtex/delivery-packages/dist/address')
 
-addOrReplaceDeliveryAddressOnList([
+setDeliveryAddressOnList([
   {
     addressId: '141125d',
     addressType: 'pickup',
@@ -1462,7 +1462,7 @@ addOrReplaceDeliveryAddressOnList([
 //   },
 // ]
 
-addOrReplaceDeliveryAddressOnList([
+setDeliveryAddressOnList([
   {
     addressId: '-4556418741084',
     addressType: 'residential',

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ $ npm install @vtex/delivery-packages
 - [groupByAddressType](#groupbyaddresstype-addresses)
 - [addOrReplaceAddressTypeOnList](#addorreplaceaddresstypeonlist-addresses-newaddress)
 - [addOrReplaceAddressOnList](#addorreplaceaddressonlist-addresses-newaddress)
+- [addOrReplaceDeliveryAddressOnList](#addorreplacedeliveryaddressonlist-addresses-newaddress)
 
 #### Delivery Channel
 
@@ -1355,6 +1356,173 @@ addOrReplaceAddressTypeOnList([
 //     country: 'BRA',
 //     reference: null,
 //     geoCoordinates: [],
+//   },
+//   {
+//     addressId: '1234',
+//     addressType: 'pickup',
+//     city: 'Rio de Janeiro',
+//     complement: '',
+//     country: 'BRA',
+//     geoCoordinates: [],
+//     neighborhood: 'Botafogo',
+//     number: '300',
+//     postalCode: '22250040',
+//     receiverName: 'auto auto',
+//     reference: null,
+//     state: 'RJ',
+//     street: 'Praia de botafogo',
+//   }
+// ]
+```
+
+**params:**
+- **addresses**
+Type: `Array<object>`
+An array which each item is an object containing all address fields like on selectedAddresses of orderForm
+- **newAddress**
+Type: `string`
+New address to be included on the list of addresses
+
+**returns:**
+- **new addresses**
+Type: `object`
+New list of addresses with the newAddress included
+
+## addOrReplaceDeliveryAddressOnList (addresses, newAddress)
+
+Adds new address if no delivery address exists on addresses and if addressType of newAddress is delivery or replace an existing address of the delivery type
+
+##### Usage
+```js
+const { addOrReplaceDeliveryAddressOnList } = require('@vtex/delivery-packages/dist/address')
+
+addOrReplaceDeliveryAddressOnList([
+  {
+    addressId: '141125d',
+    addressType: 'pickup',
+    city: 'Rio de Janeiro',
+    complement: '',
+    country: 'BRA',
+    geoCoordinates: [-43.18080139160156, -22.96540069580078],
+    neighborhood: 'Copacabana',
+    number: '5',
+    postalCode: '22011050',
+    receiverName: 'auto auto',
+    reference: null,
+    state: 'RJ',
+    street: 'Rua General Azevedo Pimentel',
+  }
+],
+
+{
+    addressId: '-4556418741084',
+    addressType: 'residential',
+    receiverName: 'John Doe',
+    street: 'Rua Barão',
+    number: '2',
+    complement: null,
+    neighborhood: 'Botafogo',
+    postalCode: '22231-100',
+    city: 'Rio de Janeiro',
+    state: 'RJ',
+    country: 'BRA',
+    reference: null,
+    geoCoordinates: [],
+  })
+// -> [
+//   {
+//     addressId: '141125d',
+//     addressType: 'pickup',
+//     city: 'Rio de Janeiro',
+//     complement: '',
+//     country: 'BRA',
+//     geoCoordinates: [-43.18080139160156, -22.96540069580078],
+//     neighborhood: 'Copacabana',
+//     number: '5',
+//     postalCode: '22011050',
+//     receiverName: 'auto auto',
+//     reference: null,
+//     state: 'RJ',
+//     street: 'Rua General Azevedo Pimentel',
+//   },
+//   {
+//     addressId: '-4556418741084',
+//     addressType: 'residential',
+//     receiverName: 'John Doe',
+//     street: 'Rua Barão',
+//     number: '2',
+//     complement: null,
+//     neighborhood: 'Botafogo',
+//     postalCode: '22231-100',
+//     city: 'Rio de Janeiro',
+//     state: 'RJ',
+//     country: 'BRA',
+//     reference: null,
+//     geoCoordinates: [],
+//   },
+// ]
+
+addOrReplaceDeliveryAddressOnList([
+  {
+    addressId: '-4556418741084',
+    addressType: 'residential',
+    receiverName: 'John Doe',
+    street: 'Rua Barão',
+    number: '2',
+    complement: null,
+    neighborhood: 'Botafogo',
+    postalCode: '22231-100',
+    city: 'Rio de Janeiro',
+    state: 'RJ',
+    country: 'BRA',
+    reference: null,
+    geoCoordinates: [],
+  },
+  {
+    addressId: '141125d',
+    addressType: 'pickup',
+    city: 'Rio de Janeiro',
+    complement: '',
+    country: 'BRA',
+    geoCoordinates: [-43.18080139160156, -22.96540069580078],
+    neighborhood: 'Copacabana',
+    number: '5',
+    postalCode: '22011050',
+    receiverName: 'auto auto',
+    reference: null,
+    state: 'RJ',
+    street: 'Rua General Azevedo Pimentel',
+  }
+], {
+  addressId: '1234',
+  addressType: 'commercial',
+  city: 'Rio de Janeiro',
+  complement: '',
+  country: 'BRA',
+  geoCoordinates: [],
+  neighborhood: 'Botafogo',
+  number: '300',
+  postalCode: '22250040',
+  receiverName: 'auto auto',
+  reference: null,
+  state: 'RJ',
+  street: 'Praia de botafogo',
+})
+// -> [
+//   {
+//     addressId: '1234',
+//     addressType: 'commercial',
+//     city: 'Rio de Janeiro',
+//     complement: '',
+//     country: 'BRA',
+//     geoCoordinates: [],
+//     neighborhood: 'Botafogo',
+//     number: '300',
+//     postalCode: '22250040',
+//     receiverName: 'auto auto',
+//     reference: null,
+//     state: 'RJ',
+//     street: 'Praia de botafogo',
 //   },
 //   {
 //     addressId: '1234',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/delivery-packages",
-  "version": "2.17.2",
+  "version": "2.18.0",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/address.js
+++ b/src/address.js
@@ -183,7 +183,7 @@ export function addOrReplaceAddressTypeOnList(addresses, newAddress) {
   return newAddresses
 }
 
-export function addOrReplaceDeliveryAddressOnList(addresses, newAddress) {
+export function setDeliveryAddressOnList(addresses, newAddress) {
   if (!addresses || !newAddress || isPickupAddress(newAddress)) {
     return addresses
   }

--- a/tests/address.test.js
+++ b/tests/address.test.js
@@ -9,7 +9,7 @@ import {
   getFirstAddressForType,
   getPickupAddress,
   addOrReplaceAddressTypeOnList,
-  addOrReplaceDeliveryAddressOnList,
+  setDeliveryAddressOnList,
   addOrReplaceAddressOnList,
   addPickupPointAddresses,
   addAddressId,
@@ -440,10 +440,10 @@ describe('Address', () => {
     })
   })
 
-  describe('addOrReplaceDeliveryAddressOnList', () => {
+  describe('setDeliveryAddressOnList', () => {
     it('should be empty if empty params are passed', () => {
-      const addresses1 = addOrReplaceDeliveryAddressOnList()
-      const addresses2 = addOrReplaceDeliveryAddressOnList([], null)
+      const addresses1 = setDeliveryAddressOnList()
+      const addresses2 = setDeliveryAddressOnList([], null)
 
       expect(addresses1).toBeUndefined()
       expect(addresses2).toEqual([])
@@ -454,7 +454,7 @@ describe('Address', () => {
       const currentAddresses = []
       const expectedAddresses = [...currentAddresses, residentialAddress]
 
-      const resultAddresses = addOrReplaceDeliveryAddressOnList(
+      const resultAddresses = setDeliveryAddressOnList(
         currentAddresses,
         residentialAddress
       )
@@ -471,7 +471,7 @@ describe('Address', () => {
       const currentAddresses = [pickupAddress, searchAddress]
       const expectedAddresses = [...currentAddresses, residentialAddress]
 
-      const resultAddresses = addOrReplaceDeliveryAddressOnList(
+      const resultAddresses = setDeliveryAddressOnList(
         currentAddresses,
         residentialAddress
       )
@@ -493,7 +493,7 @@ describe('Address', () => {
       const currentAddresses = [...baseAddresses, residentialAddress1]
       const expectedAddresses = [...baseAddresses, residentialAddress2]
 
-      const resultAddresses = addOrReplaceDeliveryAddressOnList(
+      const resultAddresses = setDeliveryAddressOnList(
         currentAddresses,
         residentialAddress2
       )
@@ -515,7 +515,7 @@ describe('Address', () => {
       const currentAddresses = [...baseAddresses, residentialAddress1]
       const expectedAddresses = [...baseAddresses, residentialAddress2]
 
-      const resultAddresses = addOrReplaceDeliveryAddressOnList(
+      const resultAddresses = setDeliveryAddressOnList(
         currentAddresses,
         residentialAddress2
       )

--- a/tests/address.test.js
+++ b/tests/address.test.js
@@ -450,56 +450,59 @@ describe('Address', () => {
     })
 
     it('should add address on empty address list', () => {
-      const residentialAddress1 = addresses.residentialAddress
-      const addresses1 = []
-      const expectedAddresses1 = [...addresses1, residentialAddress1]
+      const { residentialAddress } = addresses
+      const currentAddresses = []
+      const expectedAddresses = [...currentAddresses, residentialAddress]
 
-      const resultAddresses1 = addOrReplaceDeliveryAddressOnList(
-        addresses1,
-        residentialAddress1
+      const resultAddresses = addOrReplaceDeliveryAddressOnList(
+        currentAddresses,
+        residentialAddress
       )
 
-      expect(resultAddresses1).toEqual(expectedAddresses1)
+      expect(resultAddresses).toEqual(expectedAddresses)
     })
 
     it('should append delivery address on a list that doesnt have delivery address', () => {
-      const pickupAddress = addresses.pickupPointAddress
-      const searchAddress = addresses.searchAddress
-      const residentialAddress1 = addresses.residentialAddress
-      const addresses1 = [pickupAddress, searchAddress]
-      const expectedAddresses1 = [...addresses1, residentialAddress1]
+      const {
+        pickupPointAddress: pickupAddress,
+        searchAddress,
+        residentialAddress,
+      } = addresses
+      const currentAddresses = [pickupAddress, searchAddress]
+      const expectedAddresses = [...currentAddresses, residentialAddress]
 
-      const resultAddresses1 = addOrReplaceDeliveryAddressOnList(
-        addresses1,
-        residentialAddress1
+      const resultAddresses = addOrReplaceDeliveryAddressOnList(
+        currentAddresses,
+        residentialAddress
       )
 
-      expect(resultAddresses1).toEqual(expectedAddresses1)
+      expect(resultAddresses).toEqual(expectedAddresses)
     })
 
     it('should replace delivery address with same addressType', () => {
-      const pickupAddress = addresses.pickupPointAddress
-      const searchAddress = addresses.searchAddress
-      const residentialAddress1 = addresses.residentialAddress
+      const {
+        pickupPointAddress: pickupAddress,
+        searchAddress,
+        residentialAddress: residentialAddress1,
+      } = addresses
       const residentialAddress2 = {
         ...residentialAddress1,
         receiverName: 'Other Doe',
       }
       const baseAddresses = [pickupAddress, searchAddress]
-      const addresses1 = [...baseAddresses, residentialAddress1]
-      const expectedAddresses1 = [...baseAddresses, residentialAddress2]
+      const currentAddresses = [...baseAddresses, residentialAddress1]
+      const expectedAddresses = [...baseAddresses, residentialAddress2]
 
-      const resultAddresses1 = addOrReplaceDeliveryAddressOnList(
-        addresses1,
+      const resultAddresses = addOrReplaceDeliveryAddressOnList(
+        currentAddresses,
         residentialAddress2
       )
 
-      expect(resultAddresses1).toEqual(expectedAddresses1)
+      expect(resultAddresses).toEqual(expectedAddresses)
     })
 
     it('should replace delivery address with another delivery addressType', () => {
-      const pickupAddress = addresses.pickupPointAddress
-      const searchAddress = addresses.searchAddress
+      const { pickupPointAddress: pickupAddress, searchAddress } = addresses
       const residentialAddress1 = {
         ...addresses.residentialAddress,
         index: undefined,
@@ -509,15 +512,15 @@ describe('Address', () => {
         index: undefined,
       }
       const baseAddresses = [pickupAddress, searchAddress]
-      const addresses1 = [...baseAddresses, residentialAddress1]
-      const expectedAddresses1 = [...baseAddresses, residentialAddress2]
+      const currentAddresses = [...baseAddresses, residentialAddress1]
+      const expectedAddresses = [...baseAddresses, residentialAddress2]
 
-      const resultAddresses1 = addOrReplaceDeliveryAddressOnList(
-        addresses1,
+      const resultAddresses = addOrReplaceDeliveryAddressOnList(
+        currentAddresses,
         residentialAddress2
       )
 
-      expect(resultAddresses1).toEqual(expectedAddresses1)
+      expect(resultAddresses).toEqual(expectedAddresses)
     })
   })
 

--- a/tests/address.test.js
+++ b/tests/address.test.js
@@ -9,6 +9,7 @@ import {
   getFirstAddressForType,
   getPickupAddress,
   addOrReplaceAddressTypeOnList,
+  addOrReplaceDeliveryAddressOnList,
   addOrReplaceAddressOnList,
   addPickupPointAddresses,
   addAddressId,
@@ -49,13 +50,11 @@ describe('Address', () => {
 
     it('should be true if missing number when it is not required', () => {
       const completeAddress = { ...addresses.residentialAddress, number: null }
-      const requiredFields = [
-        'state',
-        'city',
-        'neighborhood',
-        'street',
-      ]
-      const isAddressComplete1 = isAddressComplete(completeAddress, requiredFields)
+      const requiredFields = ['state', 'city', 'neighborhood', 'street']
+      const isAddressComplete1 = isAddressComplete(
+        completeAddress,
+        requiredFields
+      )
 
       expect(isAddressComplete1).toBeTruthy()
     })
@@ -69,7 +68,10 @@ describe('Address', () => {
         'street',
         'number',
       ]
-      const isAddressComplete1 = isAddressComplete(completeAddress, requiredFields)
+      const isAddressComplete1 = isAddressComplete(
+        completeAddress,
+        requiredFields
+      )
 
       expect(isAddressComplete1).toBeFalsy()
     })
@@ -248,18 +250,12 @@ describe('Address', () => {
         ...addresses.residentialAddress,
         number: null,
       }
-      const requiredFields = [
-        'state',
-        'city',
-        'neighborhood',
-        'street',
-      ]
+      const requiredFields = ['state', 'city', 'neighborhood', 'street']
 
-      const addresses1 = getDeliveryAvailableAddresses([
-        incompleteAddress1,
-        residentialAddress1,
-        withoutNumberAddress,
-      ], requiredFields)
+      const addresses1 = getDeliveryAvailableAddresses(
+        [incompleteAddress1, residentialAddress1, withoutNumberAddress],
+        requiredFields
+      )
 
       expect(addresses1).toEqual([residentialAddress1, withoutNumberAddress])
     })
@@ -436,6 +432,87 @@ describe('Address', () => {
       const expectedAddresses1 = [...baseAddresses, residentialAddress2]
 
       const resultAddresses1 = addOrReplaceAddressTypeOnList(
+        addresses1,
+        residentialAddress2
+      )
+
+      expect(resultAddresses1).toEqual(expectedAddresses1)
+    })
+  })
+
+  describe('addOrReplaceDeliveryAddressOnList', () => {
+    it('should be empty if empty params are passed', () => {
+      const addresses1 = addOrReplaceDeliveryAddressOnList()
+      const addresses2 = addOrReplaceDeliveryAddressOnList([], null)
+
+      expect(addresses1).toBeUndefined()
+      expect(addresses2).toEqual([])
+    })
+
+    it('should add address on empty address list', () => {
+      const residentialAddress1 = addresses.residentialAddress
+      const addresses1 = []
+      const expectedAddresses1 = [...addresses1, residentialAddress1]
+
+      const resultAddresses1 = addOrReplaceDeliveryAddressOnList(
+        addresses1,
+        residentialAddress1
+      )
+
+      expect(resultAddresses1).toEqual(expectedAddresses1)
+    })
+
+    it('should append delivery address on a list that doesnt have delivery address', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const addresses1 = [pickupAddress, searchAddress]
+      const expectedAddresses1 = [...addresses1, residentialAddress1]
+
+      const resultAddresses1 = addOrReplaceDeliveryAddressOnList(
+        addresses1,
+        residentialAddress1
+      )
+
+      expect(resultAddresses1).toEqual(expectedAddresses1)
+    })
+
+    it('should replace delivery address with same addressType', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
+      const residentialAddress1 = addresses.residentialAddress
+      const residentialAddress2 = {
+        ...residentialAddress1,
+        receiverName: 'Other Doe',
+      }
+      const baseAddresses = [pickupAddress, searchAddress]
+      const addresses1 = [...baseAddresses, residentialAddress1]
+      const expectedAddresses1 = [...baseAddresses, residentialAddress2]
+
+      const resultAddresses1 = addOrReplaceDeliveryAddressOnList(
+        addresses1,
+        residentialAddress2
+      )
+
+      expect(resultAddresses1).toEqual(expectedAddresses1)
+    })
+
+    it('should replace delivery address with another delivery addressType', () => {
+      const pickupAddress = addresses.pickupPointAddress
+      const searchAddress = addresses.searchAddress
+      const residentialAddress1 = {
+        ...addresses.residentialAddress,
+        index: undefined,
+      }
+      const residentialAddress2 = {
+        ...addresses.commercialAddress,
+        index: undefined,
+      }
+      const baseAddresses = [pickupAddress, searchAddress]
+      const addresses1 = [...baseAddresses, residentialAddress1]
+      const expectedAddresses1 = [...baseAddresses, residentialAddress2]
+
+      const resultAddresses1 = addOrReplaceDeliveryAddressOnList(
         addresses1,
         residentialAddress2
       )
@@ -727,6 +804,20 @@ describe('Address', () => {
       const address1 = getFirstAddressForDelivery(addresses1)
 
       expect(address1).toEqual(residentialAddress2)
+    })
+
+    it('should find delivery address with commercial addressType', () => {
+      const pickupAddress = { ...addresses.pickupPointAddress }
+      const addresses1 = [
+        pickupAddress,
+        { ...addresses.commercialAddress },
+        { ...addresses.residentialAddress },
+      ]
+      const expectedDeliveryAddress = { ...addresses.commercialAddress }
+
+      const address1 = getFirstAddressForDelivery(addresses1)
+
+      expect(address1).toEqual(expectedDeliveryAddress)
     })
   })
 })


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add **setDeliveryAddressOnList** function that allow to correctly replace delivery address before sending to Checkout API which only allows one delivery address per orderForm

#### How should this be manually tested?

By running new jest tests

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
