### PR TITLE
chore: add SonarQube scan pipeline

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,0 +1,20 @@
+- name: delivery-packages
+  referenceId: PLACEHOLDER
+  description: SonarQube scan for delivery-packages
+  build:
+    provider: dkcicd
+    pipelines:
+      - name: node-ci-v2
+        parameters:
+          sonarProjectName: delivery-packages
+          nodeVersion: 20-bookworm
+          nodeCommands:
+            - test -- --coverage
+        runtime:
+          architecture: amd64
+        when:
+          - event: pull_request
+            source: branch
+          - event: push
+            source: branch
+            regex: master


### PR DESCRIPTION
## Summary
- Creates `.vtex/deployment.yaml` with a `node-ci-v2` pipeline for SonarQube code quality scanning
- Triggers on pull requests for PR decoration (quality gate comments)

## Context
Part of a rollout to enable SonarQube across VTEX repositories.

## Test plan
- [ ] Pipeline runs successfully on this PR
- [ ] SonarQube project appears at http://sonarqube.vtex.systems/
- [ ] PR decoration (quality gate comment) appears