### PR TITLE
chore: add test execution to CI pipeline

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -9,7 +9,7 @@
           sonarProjectName: delivery-packages
           nodeVersion: 20-bookworm
           nodeCommands:
-            - test -- --coverage
+            - test:coverage
         runtime:
           architecture: amd64
         when:

--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,5 +1,5 @@
 - name: delivery-packages
-  referenceId: PLACEHOLDER
+  referenceId: 5ZMT2PKH
   description: SonarQube scan for delivery-packages
   build:
     provider: dkcicd

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "branch": "echo $(git rev-parse --abbrev-ref HEAD) > /tmp/branch",
     "lint-only-changed": "LIST=`git diff-index --name-only HEAD | uniq | grep /.*\\.js$ | grep -v json`; if [ \"$LIST\" ]; then eslint $LIST; fi",
     "lint-not-beta": "npm run branch && if [ $(cat /tmp/branch) != \"beta\" ]; then npm run lint-only-changed; else echo 'skip lint on beta' ; fi",
-    "test-not-beta": "npm run branch && if [ $(cat /tmp/branch) != \"beta\" ]; then npm run test; else echo 'skip tests on beta' ; fi"
+    "test-not-beta": "npm run branch && if [ $(cat /tmp/branch) != \"beta\" ]; then npm run test; else echo 'skip tests on beta' ; fi",
+    "test:coverage": "jest --coverage"
   },
   "keywords": [
     "vtex",


### PR DESCRIPTION
## Summary
- Add `test:coverage` script to package.json
- Add `nodeCommands` with test step to `.vtex/deployment.yaml` so CI runs tests on PRs

## Context
Part of test-execution rollout for Checkout Experience repos. Goal: every repo runs its test suite on every PR via DK CI.

## Test plan
- [ ] Verify pipeline runs on this PR at http://dkcicd.vtex.systems/
- [ ] Verify test step executes (or stub passes if no tests)
- [ ] Confirm no regressions in existing pipeline steps

> **Note:** Any pre-existing CI failures on this repo are unrelated to this change.
